### PR TITLE
バックエンド用のアプリケーションサーバーを構築する

### DIFF
--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -18,7 +18,7 @@ resource "aws_security_group" "api" {
     from_port       = 22
     protocol        = "tcp"
     to_port         = 22
-    security_groups = ["${var.bastion_security_id}"]
+    security_groups = ["${lookup(var.bastion, "bastion_security_id")}"]
   }
 
   egress {
@@ -26,5 +26,31 @@ resource "aws_security_group" "api" {
     to_port     = 0
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_instance" "api_1a" {
+  ami                         = "${lookup(var.api, "${terraform.env}.ami", var.api["default.ami"])}"
+  associate_public_ip_address = false
+  instance_type               = "${lookup(var.api, "${terraform.env}.instance_type", var.api["default.instance_type"])}"
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_type = "${lookup(var.api, "${terraform.env}.volume_type", var.api["default.volume_type"])}"
+    volume_size = "${lookup(var.api, "${terraform.env}.volume_size", var.api["default.volume_size"])}"
+  }
+
+  key_name               = "${lookup(var.bastion, "key_pair_id")}"
+  subnet_id              = "${var.vpc["subnet_private_1a_id"]}"
+  vpc_security_group_ids = ["${aws_security_group.api.id}"]
+
+  tags {
+    Name = "${terraform.workspace}_${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}_1a"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      "*",
+    ]
   }
 }

--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -1,0 +1,30 @@
+resource "aws_security_group" "api" {
+  name        = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}"
+  description = "Security Group to ${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}"
+  vpc_id      = "${lookup(var.vpc, "vpc_id")}"
+
+  tags {
+    Name = "${terraform.workspace}_${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}"
+  }
+
+  ingress {
+    from_port   = 80
+    protocol    = "tcp"
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port       = 22
+    protocol        = "tcp"
+    to_port         = 22
+    security_groups = ["${var.bastion_security_id}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/modules/aws/api/variable.tf
+++ b/modules/aws/api/variable.tf
@@ -4,7 +4,7 @@ variable "api" {
   default = {
     default.name          = "api"
     default.ami           = "ami-00f9d04b3b3092052"
-    default.instance_type = "t3.micro"
+    default.instance_type = "t2.micro"
     default.volume_type   = "gp2"
     default.volume_size   = "8"
   }
@@ -16,8 +16,8 @@ variable "vpc" {
   default = {}
 }
 
-variable "bastion_security_id" {
-  type = "string"
+variable "bastion" {
+  type = "map"
 
-  default = ""
+  default = {}
 }

--- a/modules/aws/api/variable.tf
+++ b/modules/aws/api/variable.tf
@@ -1,0 +1,23 @@
+variable "api" {
+  type = "map"
+
+  default = {
+    default.name          = "api"
+    default.ami           = "ami-00f9d04b3b3092052"
+    default.instance_type = "t3.micro"
+    default.volume_type   = "gp2"
+    default.volume_size   = "8"
+  }
+}
+
+variable "vpc" {
+  type = "map"
+
+  default = {}
+}
+
+variable "bastion_security_id" {
+  type = "string"
+
+  default = ""
+}

--- a/modules/aws/bastion/output.tf
+++ b/modules/aws/bastion/output.tf
@@ -1,0 +1,3 @@
+output "bastion_security_id" {
+  value = "${aws_security_group.bastion.id}"
+}

--- a/modules/aws/bastion/output.tf
+++ b/modules/aws/bastion/output.tf
@@ -1,3 +1,8 @@
-output "bastion_security_id" {
-  value = "${aws_security_group.bastion.id}"
+output "bastion" {
+  value = "${
+    map(
+      "bastion_security_id", "${aws_security_group.bastion.id}",
+      "key_pair_id", "${aws_key_pair.ssh_key_pair.id}"
+    )
+  }"
 }

--- a/modules/aws/vpc/output.tf
+++ b/modules/aws/vpc/output.tf
@@ -4,7 +4,10 @@ output "vpc" {
       "vpc_id", "${aws_vpc.vpc.id}",
       "subnet_public_1a_id", "${aws_subnet.public_1a.id}",
       "subnet_public_1c_id", "${aws_subnet.public_1c.id}",
-      "subnet_public_1d_id", "${aws_subnet.public_1d.id}"
+      "subnet_public_1d_id", "${aws_subnet.public_1d.id}",
+      "subnet_private_1a_id", "${aws_subnet.private_1a.id}",
+      "subnet_private_1c_id", "${aws_subnet.private_1c.id}",
+      "subnet_private_1d_id", "${aws_subnet.private_1d.id}"
     )
   }"
 }

--- a/providers/aws/environments/20-bastion/output.tf
+++ b/providers/aws/environments/20-bastion/output.tf
@@ -1,0 +1,3 @@
+output "bastion_security_id" {
+  value = "${module.bastion.bastion_security_id}"
+}

--- a/providers/aws/environments/20-bastion/output.tf
+++ b/providers/aws/environments/20-bastion/output.tf
@@ -1,3 +1,3 @@
-output "bastion_security_id" {
-  value = "${module.bastion.bastion_security_id}"
+output "bastion" {
+  value = "${module.bastion.bastion}"
 }

--- a/providers/aws/environments/21-api/backend.tf
+++ b/providers/aws/environments/21-api/backend.tf
@@ -20,7 +20,7 @@ data "terraform_remote_state" "network" {
   }
 }
 
-data "terraform_remote_state" "backend" {
+data "terraform_remote_state" "bastion" {
   backend = "s3"
 
   config {

--- a/providers/aws/environments/21-api/backend.tf
+++ b/providers/aws/environments/21-api/backend.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = "=0.11.10"
+
+  backend "s3" {
+    bucket  = "dev-qiita-stocker-tfstate"
+    key     = "api/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "qiita-stocker-dev"
+  }
+}
+
+data "terraform_remote_state" "network" {
+  backend = "s3"
+
+  config {
+    bucket  = "dev-qiita-stocker-tfstate"
+    key     = "env:/${terraform.env}/network/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "qiita-stocker-dev"
+  }
+}
+
+data "terraform_remote_state" "bastion" {
+  backend = "s3"
+
+  config {
+    bucket  = "dev-qiita-stocker-tfstate"
+    key     = "env:/${terraform.env}/bastion/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "qiita-stocker-dev"
+  }
+}

--- a/providers/aws/environments/21-api/backend.tf
+++ b/providers/aws/environments/21-api/backend.tf
@@ -20,7 +20,7 @@ data "terraform_remote_state" "network" {
   }
 }
 
-data "terraform_remote_state" "bastion" {
+data "terraform_remote_state" "backend" {
   backend = "s3"
 
   config {

--- a/providers/aws/environments/21-api/main.tf
+++ b/providers/aws/environments/21-api/main.tf
@@ -1,0 +1,5 @@
+module "bastion" {
+  source              = "../../../../modules/aws/api"
+  vpc                 = "${data.terraform_remote_state.network.vpc}"
+  bastion_security_id = "${data.terraform_remote_state.bastion.bastion_security_id}"
+}

--- a/providers/aws/environments/21-api/main.tf
+++ b/providers/aws/environments/21-api/main.tf
@@ -1,5 +1,5 @@
 module "bastion" {
-  source              = "../../../../modules/aws/api"
-  vpc                 = "${data.terraform_remote_state.network.vpc}"
-  bastion_security_id = "${data.terraform_remote_state.bastion.bastion_security_id}"
+  source  = "../../../../modules/aws/api"
+  vpc     = "${data.terraform_remote_state.network.vpc}"
+  bastion = "${data.terraform_remote_state.backend.bastion}"
 }

--- a/providers/aws/environments/21-api/main.tf
+++ b/providers/aws/environments/21-api/main.tf
@@ -1,5 +1,5 @@
 module "bastion" {
   source  = "../../../../modules/aws/api"
   vpc     = "${data.terraform_remote_state.network.vpc}"
-  bastion = "${data.terraform_remote_state.backend.bastion}"
+  bastion = "${data.terraform_remote_state.bastion.bastion}"
 }

--- a/providers/aws/environments/21-api/provider.tf
+++ b/providers/aws/environments/21-api/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  version = "=1.49.0"
+  region  = "ap-northeast-1"
+  profile = "qiita-stocker-dev"
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/6

# Doneの定義
- インスタンスが作成され80ポート（httpのデフォルトポートが開放されている事）
- BastionサーバーからSSH接続が可能になっている事

# 変更点概要

## 技術的変更点概要
privateサブネットにAPIサーバーを構築。
BastionサーバーからSSH接続が可能であることを確認。

# 補足情報
ディレクトリ構成について、[Terraformの構成 ver.2017冬](https://qiita.com/uraura/items/e13d883827443f27bf98)を参考にした。
`21_api`としているのは、`21_api`が`20_bastion`に依存していることを表すため`21`という数字にした。

T3インスタンスで作成しようと思ったが、以下のエラーとなったため暫定でT2インスタンスで作成した。
必要があれば、制限緩和のリクエストを行う。
https://docs.aws.amazon.com/ja_jp/AWSEC2/latest/UserGuide/troubleshooting-launch.html#troubleshooting-launch-limit