### PR TITLE
CloudFront + S3Bucketを作成する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ crash.log
 qiita-stocker-terraform.iml
 
 providers/aws/environments/20-bastion/terraform.tfvars
+providers/aws/environments/11-acm/terraform.tfvars
+providers/aws/environments/22-frontend/terraform.tfvars

--- a/modules/aws/acm/main.tf
+++ b/modules/aws/acm/main.tf
@@ -1,0 +1,3 @@
+data "aws_acm_certificate" "main" {
+  domain = "*.${var.main_domain_name}"
+}

--- a/modules/aws/acm/output.tf
+++ b/modules/aws/acm/output.tf
@@ -1,0 +1,7 @@
+output "acm" {
+  value = "${
+    map(
+      "main_arn", "${data.aws_acm_certificate.main.arn}"
+    )
+  }"
+}

--- a/modules/aws/acm/variable.tf
+++ b/modules/aws/acm/variable.tf
@@ -1,4 +1,4 @@
-variable "ssh_public_key_path" {
+variable "main_domain_name" {
   type = "string"
 
   default = ""

--- a/modules/aws/frontend/main.tf
+++ b/modules/aws/frontend/main.tf
@@ -1,4 +1,108 @@
 resource "aws_s3_bucket" "web" {
-  bucket        = "${terraform.workspace}-${var.frontend["default.bucket"]}"
+  bucket        = "${terraform.workspace}-${var.bucket}"
   force_destroy = true
+}
+
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.web.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${aws_cloudfront_origin_access_identity.origin_access_identity.iam_arn}"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "web" {
+  bucket = "${aws_s3_bucket.web.id}"
+  policy = "${data.aws_iam_policy_document.s3_policy.json}"
+}
+
+resource "aws_cloudfront_origin_access_identity" "origin_access_identity" {
+  comment = "access-identity-S3-${terraform.workspace}-${var.bucket}"
+}
+
+data "aws_route53_zone" "web" {
+  name = "${var.main_domain_name}"
+}
+
+resource "aws_route53_record" "web" {
+  zone_id = "${data.aws_route53_zone.web.zone_id}"
+  name    = "${terraform.workspace}-${var.sub_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_cloudfront_distribution.web.domain_name}"
+    zone_id                = "${aws_cloudfront_distribution.web.hosted_zone_id}"
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_cloudfront_distribution" "web" {
+  origin {
+    domain_name = "${aws_s3_bucket.web.bucket_regional_domain_name}"
+    origin_id   = "S3-${terraform.workspace}-${var.bucket}"
+
+    s3_origin_config {
+      origin_access_identity = "${aws_cloudfront_origin_access_identity.origin_access_identity.cloudfront_access_identity_path}"
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+
+  aliases = ["${terraform.workspace}-${var.sub_domain_name}.${var.main_domain_name}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    compress         = false
+    target_origin_id = "S3-${terraform.workspace}-${var.bucket}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+
+    min_ttl     = 0
+    default_ttl = 86400
+    max_ttl     = 31536000
+  }
+
+  price_class = "PriceClass_All"
+
+  custom_error_response {
+    error_caching_min_ttl = 300
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = 300
+    error_code            = 404
+    response_code         = 404
+    response_page_path    = "/index.html"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    acm_certificate_arn            = "${lookup(var.acm, "main_arn")}"
+    ssl_support_method             = "sni-only"
+    minimum_protocol_version       = "TLSv1.1_2016"
+  }
 }

--- a/modules/aws/frontend/main.tf
+++ b/modules/aws/frontend/main.tf
@@ -1,0 +1,4 @@
+resource "aws_s3_bucket" "web" {
+  bucket        = "${terraform.workspace}-${var.frontend["default.bucket"]}"
+  force_destroy = true
+}

--- a/modules/aws/frontend/variable.tf
+++ b/modules/aws/frontend/variable.tf
@@ -1,0 +1,7 @@
+variable "frontend" {
+  type = "map"
+
+  default = {
+    default.bucket = "qiita-stocker-frontend"
+  }
+}

--- a/modules/aws/frontend/variable.tf
+++ b/modules/aws/frontend/variable.tf
@@ -1,7 +1,23 @@
-variable "frontend" {
+variable "bucket" {
+  type = "string"
+
+  default = "qiita-stocker-frontend"
+}
+
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}
+
+variable "sub_domain_name" {
+  type = "string"
+
+  default = "www"
+}
+
+variable "acm" {
   type = "map"
 
-  default = {
-    default.bucket = "qiita-stocker-frontend"
-  }
+  default = {}
 }

--- a/providers/aws/environments/11-acm/backend.tf
+++ b/providers/aws/environments/11-acm/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "=0.11.10"
+
+  backend "s3" {
+    bucket  = "dev-qiita-stocker-tfstate"
+    key     = "acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "qiita-stocker-dev"
+  }
+}

--- a/providers/aws/environments/11-acm/main.tf
+++ b/providers/aws/environments/11-acm/main.tf
@@ -1,0 +1,4 @@
+module "acm" {
+  source           = "../../../../modules/aws/acm"
+  main_domain_name = "${var.main_domain_name}"
+}

--- a/providers/aws/environments/11-acm/output.tf
+++ b/providers/aws/environments/11-acm/output.tf
@@ -1,0 +1,3 @@
+output "acm" {
+  value = "${module.acm.acm}"
+}

--- a/providers/aws/environments/11-acm/provider.tf
+++ b/providers/aws/environments/11-acm/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  version = "=1.49.0"
+  region  = "us-east-1"
+  profile = "qiita-stocker-dev"
+}

--- a/providers/aws/environments/11-acm/variable.tf
+++ b/providers/aws/environments/11-acm/variable.tf
@@ -1,0 +1,5 @@
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}

--- a/providers/aws/environments/22-frontend/backend.tf
+++ b/providers/aws/environments/22-frontend/backend.tf
@@ -8,3 +8,14 @@ terraform {
     profile = "qiita-stocker-dev"
   }
 }
+
+data "terraform_remote_state" "acm" {
+  backend = "s3"
+
+  config {
+    bucket  = "dev-qiita-stocker-tfstate"
+    key     = "env:/${terraform.env}/acm/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "qiita-stocker-dev"
+  }
+}

--- a/providers/aws/environments/22-frontend/backend.tf
+++ b/providers/aws/environments/22-frontend/backend.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "=0.11.10"
+
+  backend "s3" {
+    bucket  = "dev-qiita-stocker-tfstate"
+    key     = "frontend/terraform.tfstate"
+    region  = "ap-northeast-1"
+    profile = "qiita-stocker-dev"
+  }
+}

--- a/providers/aws/environments/22-frontend/main.tf
+++ b/providers/aws/environments/22-frontend/main.tf
@@ -1,0 +1,3 @@
+module "front" {
+  source = "../../../../modules/aws/frontend"
+}

--- a/providers/aws/environments/22-frontend/main.tf
+++ b/providers/aws/environments/22-frontend/main.tf
@@ -1,3 +1,5 @@
 module "front" {
-  source = "../../../../modules/aws/frontend"
+  source           = "../../../../modules/aws/frontend"
+  acm              = "${data.terraform_remote_state.acm.acm}"
+  main_domain_name = "${var.main_domain_name}"
 }

--- a/providers/aws/environments/22-frontend/provider.tf
+++ b/providers/aws/environments/22-frontend/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  version = "=1.49.0"
+  region  = "ap-northeast-1"
+  profile = "qiita-stocker-dev"
+}

--- a/providers/aws/environments/22-frontend/variable.tf
+++ b/providers/aws/environments/22-frontend/variable.tf
@@ -1,0 +1,5 @@
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/4

# Doneの定義
- CloudFrontとS3BucketでSPAアプリケーションが配信出来る状態になっている事
- 購入した独自ドメインでアクセス出来るようになっている事

# 変更点概要

## 技術的変更点概要
S3BucketとCloudFrontを作成。
`providers/aws/environments/11-acm`を作成し、`バージニア北部`リージョンに作成した証明書を取得している。
`providers/aws/environments/22-frontend`では、S3BucketとCloudFrontを作成を行なっている。

作成したアプリケーションに接続できることを確認済み。