### PR TITLE
アプリケーションサーバーをALB経由で接続可能にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ crash.log
 .idea
 qiita-stocker-terraform.iml
 
-providers/aws/environments/20-bastion/terraform.tfvars
 providers/aws/environments/11-acm/terraform.tfvars
+providers/aws/environments/20-bastion/terraform.tfvars
+providers/aws/environments/21-api/terraform.tfvars
 providers/aws/environments/22-frontend/terraform.tfvars

--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -8,10 +8,17 @@ resource "aws_security_group" "api" {
   }
 
   ingress {
-    from_port   = 80
-    protocol    = "tcp"
-    to_port     = 80
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port       = 80
+    protocol        = "tcp"
+    to_port         = 80
+    security_groups = ["${aws_security_group.alb.id}"]
+  }
+
+  ingress {
+    from_port       = 80
+    protocol        = "tcp"
+    to_port         = 80
+    security_groups = ["${lookup(var.bastion, "bastion_security_id")}"]
   }
 
   ingress {
@@ -19,6 +26,37 @@ resource "aws_security_group" "api" {
     protocol        = "tcp"
     to_port         = 22
     security_groups = ["${lookup(var.bastion, "bastion_security_id")}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "alb" {
+  name        = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}-alb"
+  description = "Security Group to ${lookup(var.api, "${terraform.env}.name", var.api["default.name"])} alb"
+  vpc_id      = "${lookup(var.vpc, "vpc_id")}"
+
+  tags {
+    Name = "${terraform.workspace}_${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}-alb"
+  }
+
+  ingress {
+    from_port   = 80
+    protocol    = "tcp"
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    protocol    = "tcp"
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   egress {
@@ -52,5 +90,92 @@ resource "aws_instance" "api_1a" {
     ignore_changes = [
       "*",
     ]
+  }
+}
+
+resource "aws_s3_bucket" "api_alb_logs" {
+  bucket        = "${terraform.workspace}-${var.api["default.project"]}-${var.api["default.name"]}-alb-logs"
+  force_destroy = true
+}
+
+data "aws_iam_policy_document" "put_api_alb_logs_policy" {
+  "statement" {
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.api_alb_logs.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_elb_service_account.aws_elb_service_account.id}"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "api" {
+  bucket = "${aws_s3_bucket.api_alb_logs.id}"
+  policy = "${data.aws_iam_policy_document.put_api_alb_logs_policy.json}"
+}
+
+resource "aws_lb" "api" {
+  name               = "${terraform.workspace}-${var.api["default.name"]}"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = ["${aws_security_group.alb.id}"]
+  subnets            = ["${var.vpc["subnet_public_1a_id"]}", "${var.vpc["subnet_public_1c_id"]}", "${var.vpc["subnet_public_1d_id"]}"]
+
+  enable_deletion_protection = false
+
+  access_logs {
+    enabled = true
+    bucket  = "${aws_s3_bucket.api_alb_logs.bucket}"
+  }
+
+  tags {
+    Name = "${terraform.workspace}_${var.api["default.name"]}_alb"
+  }
+}
+
+resource "aws_lb_target_group" "api" {
+  name     = "${terraform.workspace}-${var.api["default.name"]}"
+  port     = "80"
+  protocol = "HTTP"
+  vpc_id   = "${lookup(var.vpc, "vpc_id")}"
+
+  health_check {
+    path                = "/"
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    interval            = 20
+    matcher             = 200
+  }
+}
+
+resource "aws_alb_target_group_attachment" "api_alb_attachment" {
+  target_group_arn = "${aws_lb_target_group.api.arn}"
+  target_id        = "${aws_instance.api_1a.id}"
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = "${aws_lb.api.arn}"
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.api.arn}"
+    type             = "forward"
+  }
+}
+
+resource "aws_lb_listener" "https" {
+  load_balancer_arn = "${aws_lb.api.arn}"
+  port              = 443
+  protocol          = "HTTPS"
+
+  ssl_policy      = "ELBSecurityPolicy-2016-08"
+  certificate_arn = "arn:aws:acm:ap-northeast-1:310040406861:certificate/b820d76f-4473-4ec1-a639-d2a623b4109e"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.api.arn}"
+    type             = "forward"
   }
 }

--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -172,7 +172,7 @@ resource "aws_lb_listener" "https" {
   protocol          = "HTTPS"
 
   ssl_policy      = "ELBSecurityPolicy-2016-08"
-  certificate_arn = "arn:aws:acm:ap-northeast-1:310040406861:certificate/b820d76f-4473-4ec1-a639-d2a623b4109e"
+  certificate_arn = "${data.aws_acm_certificate.main.arn}"
 
   default_action {
     target_group_arn = "${aws_lb_target_group.api.arn}"

--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -1,5 +1,5 @@
 resource "aws_security_group" "api" {
-  name        = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}"
+  name        = "${terraform.workspace}_${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}"
   description = "Security Group to ${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}"
   vpc_id      = "${lookup(var.vpc, "vpc_id")}"
 
@@ -37,12 +37,12 @@ resource "aws_security_group" "api" {
 }
 
 resource "aws_security_group" "alb" {
-  name        = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}-alb"
+  name        = "${terraform.workspace}_${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}_alb"
   description = "Security Group to ${lookup(var.api, "${terraform.env}.name", var.api["default.name"])} alb"
   vpc_id      = "${lookup(var.vpc, "vpc_id")}"
 
   tags {
-    Name = "${terraform.workspace}_${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}-alb"
+    Name = "${terraform.workspace}_${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}_alb"
   }
 
   ingress {

--- a/modules/aws/api/variable.tf
+++ b/modules/aws/api/variable.tf
@@ -23,4 +23,14 @@ variable "bastion" {
   default = {}
 }
 
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}
+
 data "aws_elb_service_account" "aws_elb_service_account" {}
+
+data "aws_acm_certificate" "main" {
+  domain = "*.${var.main_domain_name}"
+}

--- a/modules/aws/api/variable.tf
+++ b/modules/aws/api/variable.tf
@@ -2,6 +2,7 @@ variable "api" {
   type = "map"
 
   default = {
+    default.project       = "qiita-stocker"
     default.name          = "api"
     default.ami           = "ami-00f9d04b3b3092052"
     default.instance_type = "t2.micro"
@@ -21,3 +22,5 @@ variable "bastion" {
 
   default = {}
 }
+
+data "aws_elb_service_account" "aws_elb_service_account" {}

--- a/providers/aws/environments/20-bastion/variable.tf
+++ b/providers/aws/environments/20-bastion/variable.tf
@@ -1,0 +1,5 @@
+variable "ssh_public_key_path" {
+  type = "string"
+
+  default = ""
+}

--- a/providers/aws/environments/21-api/main.tf
+++ b/providers/aws/environments/21-api/main.tf
@@ -1,4 +1,4 @@
-module "bastion" {
+module "api" {
   source  = "../../../../modules/aws/api"
   vpc     = "${data.terraform_remote_state.network.vpc}"
   bastion = "${data.terraform_remote_state.bastion.bastion}"

--- a/providers/aws/environments/21-api/main.tf
+++ b/providers/aws/environments/21-api/main.tf
@@ -1,5 +1,6 @@
 module "api" {
-  source  = "../../../../modules/aws/api"
-  vpc     = "${data.terraform_remote_state.network.vpc}"
-  bastion = "${data.terraform_remote_state.bastion.bastion}"
+  source           = "../../../../modules/aws/api"
+  vpc              = "${data.terraform_remote_state.network.vpc}"
+  bastion          = "${data.terraform_remote_state.bastion.bastion}"
+  main_domain_name = "${var.main_domain_name}"
 }

--- a/providers/aws/environments/21-api/variable.tf
+++ b/providers/aws/environments/21-api/variable.tf
@@ -1,0 +1,5 @@
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/10

# Doneの定義
- ALB経由でアプリケーションサーバーに接続できること
- HTTPSで外部から接続可能になっている事

# 変更点概要

## 技術的変更点概要
`modules/aws/api/main.tf`にALBを構築する処理を追加。
アクセスログを出力するための、S3Bucketについても作成している。