### PR TITLE
アプリケーションサーバーが独自のドメインで接続出来るようにする

### DIFF
--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -186,7 +186,7 @@ data "aws_route53_zone" "api" {
 
 resource "aws_route53_record" "api" {
   zone_id = "${data.aws_route53_zone.api.zone_id}"
-  name    = "${terraform.workspace}-${var.sub_domain_name}"
+  name    = "${lookup(var.sub_domain_name, "${terraform.env}.name", var.sub_domain_name["default.name"])}"
   type    = "A"
 
   alias {

--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -179,3 +179,19 @@ resource "aws_lb_listener" "https" {
     type             = "forward"
   }
 }
+
+data "aws_route53_zone" "api" {
+  name = "${var.main_domain_name}"
+}
+
+resource "aws_route53_record" "api" {
+  zone_id = "${data.aws_route53_zone.api.zone_id}"
+  name    = "${terraform.workspace}-${var.sub_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.api.dns_name}"
+    zone_id                = "${aws_lb.api.zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/modules/aws/api/variable.tf
+++ b/modules/aws/api/variable.tf
@@ -29,6 +29,12 @@ variable "main_domain_name" {
   default = ""
 }
 
+variable "sub_domain_name" {
+  type = "string"
+
+  default = "api"
+}
+
 data "aws_elb_service_account" "aws_elb_service_account" {}
 
 data "aws_acm_certificate" "main" {

--- a/modules/aws/api/variable.tf
+++ b/modules/aws/api/variable.tf
@@ -30,9 +30,12 @@ variable "main_domain_name" {
 }
 
 variable "sub_domain_name" {
-  type = "string"
+  type = "map"
 
-  default = "api"
+  default = {
+    stg.name     = "stg-api"
+    default.name = "api"
+  }
 }
 
 data "aws_elb_service_account" "aws_elb_service_account" {}

--- a/modules/aws/frontend/main.tf
+++ b/modules/aws/frontend/main.tf
@@ -52,7 +52,7 @@ data "aws_route53_zone" "web" {
 
 resource "aws_route53_record" "web" {
   zone_id = "${data.aws_route53_zone.web.zone_id}"
-  name    = "${terraform.workspace}-${var.sub_domain_name}"
+  name    = "${lookup(var.sub_domain_name, "${terraform.env}.name", var.sub_domain_name["default.name"])}"
   type    = "A"
 
   alias {
@@ -82,7 +82,7 @@ resource "aws_cloudfront_distribution" "web" {
   is_ipv6_enabled     = true
   default_root_object = "index.html"
 
-  aliases = ["${terraform.workspace}-${var.sub_domain_name}.${var.main_domain_name}"]
+  aliases = ["${lookup(var.sub_domain_name, "${terraform.env}.name", var.sub_domain_name["default.name"])}.${var.main_domain_name}"]
 
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]

--- a/modules/aws/frontend/variable.tf
+++ b/modules/aws/frontend/variable.tf
@@ -11,9 +11,12 @@ variable "main_domain_name" {
 }
 
 variable "sub_domain_name" {
-  type = "string"
+  type = "map"
 
-  default = "www"
+  default = {
+    stg.name     = "stg-www"
+    default.name = "www"
+  }
 }
 
 variable "acm" {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/12

# Doneの定義
- アプリケーションサーバーに独自のドメインで接続出来ること

# 変更点概要

## 仕様的変更点概要
APIサーバーに独自ドメインで接続できるように修正。

## 技術的変更点概要
ドメインにAレコードを追加。