### PR TITLE
ネットワークACLを構築する

### DIFF
--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -46,13 +46,6 @@ resource "aws_security_group" "alb" {
   }
 
   ingress {
-    from_port   = 80
-    protocol    = "tcp"
-    to_port     = 80
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
-  ingress {
     from_port   = 443
     protocol    = "tcp"
     to_port     = 443
@@ -153,17 +146,6 @@ resource "aws_lb_target_group" "api" {
 resource "aws_alb_target_group_attachment" "api_alb_attachment" {
   target_group_arn = "${aws_lb_target_group.api.arn}"
   target_id        = "${aws_instance.api_1a.id}"
-}
-
-resource "aws_lb_listener" "http" {
-  load_balancer_arn = "${aws_lb.api.arn}"
-  port              = 80
-  protocol          = "HTTP"
-
-  default_action {
-    target_group_arn = "${aws_lb_target_group.api.arn}"
-    type             = "forward"
-  }
 }
 
 resource "aws_lb_listener" "https" {

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -146,3 +146,211 @@ resource "aws_route_table_association" "private_1d" {
   route_table_id = "${aws_route_table.private.id}"
   subnet_id      = "${aws_subnet.private_1d.id}"
 }
+
+resource "aws_network_acl" "public" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  ingress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3389
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 3389
+    cidr_block = "${aws_vpc.vpc.cidr_block}"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 3306
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 3306
+    cidr_block = "${aws_vpc.vpc.cidr_block}"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  subnet_ids = [
+    "${aws_subnet.public_1a.id}",
+    "${aws_subnet.public_1c.id}",
+    "${aws_subnet.public_1d.id}",
+  ]
+
+  tags {
+    Name = "${terraform.workspace}_public"
+  }
+}
+
+resource "aws_network_acl" "private" {
+  vpc_id = "${aws_vpc.vpc.id}"
+
+  ingress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "${aws_vpc.vpc.cidr_block}"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "${aws_vpc.vpc.cidr_block}"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 22
+    cidr_block = "${aws_vpc.vpc.cidr_block}"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3306
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 3306
+    cidr_block = "${aws_vpc.vpc.cidr_block}"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 3389
+    protocol   = "tcp"
+    rule_no    = 140
+    to_port    = 3389
+    cidr_block = "${aws_vpc.vpc.cidr_block}"
+  }
+
+  ingress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 150
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 80
+    protocol   = "tcp"
+    rule_no    = 100
+    to_port    = 80
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 443
+    protocol   = "tcp"
+    rule_no    = 110
+    to_port    = 443
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 1024
+    protocol   = "tcp"
+    rule_no    = 120
+    to_port    = 65535
+    cidr_block = "0.0.0.0/0"
+  }
+
+  egress {
+    action     = "allow"
+    from_port  = 22
+    protocol   = "tcp"
+    rule_no    = 130
+    to_port    = 22
+    cidr_block = "0.0.0.0/0"
+  }
+
+  subnet_ids = [
+    "${aws_subnet.private_1a.id}",
+    "${aws_subnet.private_1c.id}",
+    "${aws_subnet.private_1d.id}",
+  ]
+
+  tags {
+    Name = "${terraform.workspace}_private"
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/16

# Doneの定義
- ネットワークACLが構築されていること
- 接続可能であること

# 変更点概要

## 技術的変更点概要
NetworkACLを構築。
今回のIssueとは関係ないが、アプリケーションサーバーのALBのリスナーからポート80を削除。

VPCに接続可能なことを確認済み。