### PR TITLE
ALBにAPIサーバーをアタッチする処理を削除する

### DIFF
--- a/modules/aws/api/main.tf
+++ b/modules/aws/api/main.tf
@@ -143,11 +143,6 @@ resource "aws_lb_target_group" "api" {
   }
 }
 
-resource "aws_alb_target_group_attachment" "api_alb_attachment" {
-  target_group_arn = "${aws_lb_target_group.api.arn}"
-  target_id        = "${aws_instance.api_1a.id}"
-}
-
 resource "aws_lb_listener" "https" {
   load_balancer_arn = "${aws_lb.api.arn}"
   port              = 443

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -115,8 +115,12 @@ resource "aws_rds_cluster_parameter_group" "database_cluster_parameter_group" {
 }
 
 resource "aws_route53_zone" "rds_local_domain_name" {
-  name    = "${terraform.workspace}"
-  vpc_id  = "${lookup(var.vpc, "vpc_id")}"
+  name = "${terraform.workspace}"
+
+  vpc {
+    vpc_id = "${lookup(var.vpc, "vpc_id")}"
+  }
+
   comment = "${terraform.workspace} RDS Local Domain"
 }
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/26

# Doneの定義
- https://github.com/nekochans/qiita-stocker-terraform/issues/26 の完了条件を満たしている事

# 変更点概要

## 仕様的変更点概要
- terraform実行時にALBにインスタンスをアタッチしないように変更

## 技術的変更点概要
- `aws_alb_target_group_attachment ` を削除

# 補足情報
理由は https://github.com/nekochans/qiita-stocker-terraform/issues/26 に書いてある通り、デプロイ時に新しいインスタンスを作る度にAPIサーバーが停止してしまう為。

このPRの趣旨とはズレるが [こちらのコミット](https://github.com/nekochans/qiita-stocker-terraform/pull/27/commits/3b965b3c8c310230a28f6bde63fbb0b5a2d484e1) でterraformからの警告メッセージが出ていたので対応を行ってある。

出ていた警告メッセージは下記の通り。

```
Warning: module.rds.aws_route53_zone.rds_local_domain_name: "vpc_id": [DEPRECATED] use 'vpc' attribute instead
```