### PR TITLE
EC2インスタンスのIAMロールをUpdate

### DIFF
--- a/modules/aws/api/ec2.tf
+++ b/modules/aws/api/ec2.tf
@@ -60,6 +60,11 @@ data "aws_iam_policy_document" "ec2_policy" {
       "codedeploy:Get*",
       "codedeploy:List*",
       "codedeploy:RegisterApplicationRevision",
+      "cloudwatch:PutMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+      "ec2:DescribeTags",
+      "kinesis:*",
     ]
 
     resources = ["*"]


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/30

# Doneの定義
- https://github.com/nekochans/qiita-stocker-terraform/issues/30 の完了条件を満たしている事

# 変更点概要
![metrics](https://user-images.githubusercontent.com/11032365/51086377-93d9e580-1789-11e9-8515-777594443da2.png)

## 仕様的変更点概要
メモリ、ディスク使用量をCloudWatchMetricsに送信する処理を追加。

## 技術的変更点概要

IAMロールに以下の権限を追加。

```
cloudwatch:PutMetricData
cloudwatch:GetMetricStatistics
cloudwatch:ListMetrics
ec2:DescribeTags
kinesis:*
```

`kinesis:*` に関しては今回の対応とは関係はないが、後にアプリケーションログを送信する際に必要になるので追加した。