### PR TITLE
backendで利用するCodeBuild用のリソースを作成

### DIFF
--- a/modules/aws/api/codebuild.tf
+++ b/modules/aws/api/codebuild.tf
@@ -10,6 +10,8 @@ data "aws_iam_policy_document" "codebuild_trust_relationship" {
       identifiers = [
         "codebuild.amazonaws.com",
         "codedeploy.amazonaws.com",
+        "secretsmanager.amazonaws.com",
+        "s3.amazonaws.com",
       ]
     }
   }
@@ -20,19 +22,11 @@ resource "aws_iam_role" "codebuild_role" {
   assume_role_policy = "${data.aws_iam_policy_document.codebuild_trust_relationship.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "attach_codebuild_admin_to_codebuild_role" {
+// TODO 本当は良くないけど適切な権限設定が分からなかったのでAdministratorAccessを付与しておく
+// TODO 適切な権限設定が分かった時点で権限を見直す
+resource "aws_iam_role_policy_attachment" "attach_admin_access_to_codebuild_role" {
   role       = "${aws_iam_role.codebuild_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/AWSCodeBuildAdminAccess"
-}
-
-resource "aws_iam_role_policy_attachment" "attach_codedeploy_admin_to_codebuild_role" {
-  role       = "${aws_iam_role.codebuild_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
-}
-
-resource "aws_iam_role_policy_attachment" "attach_cloudwatch_admin_to_codebuild_role" {
-  role       = "${aws_iam_role.codebuild_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
 }
 
 resource "aws_codebuild_project" "api" {

--- a/modules/aws/api/codebuild.tf
+++ b/modules/aws/api/codebuild.tf
@@ -1,0 +1,62 @@
+data "aws_iam_policy_document" "codebuild_trust_relationship" {
+  "statement" {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "codebuild.amazonaws.com",
+        "codedeploy.amazonaws.com",
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "codebuild_role" {
+  name               = "${terraform.workspace}-codebuild-role"
+  assume_role_policy = "${data.aws_iam_policy_document.codebuild_trust_relationship.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_codebuild_admin_to_codebuild_role" {
+  role       = "${aws_iam_role.codebuild_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeBuildAdminAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_codedeploy_admin_to_codebuild_role" {
+  role       = "${aws_iam_role.codebuild_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+}
+
+resource "aws_iam_role_policy_attachment" "attach_cloudwatch_admin_to_codebuild_role" {
+  role       = "${aws_iam_role.codebuild_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/CloudWatchFullAccess"
+}
+
+resource "aws_codebuild_project" "api" {
+  "artifacts" {
+    type = "NO_ARTIFACTS"
+  }
+
+  "environment" {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/nodejs:10.14.1"
+    type         = "LINUX_CONTAINER"
+
+    environment_variable {
+      name  = "DEPLOY_STAGE"
+      value = "${terraform.workspace}"
+    }
+  }
+
+  name         = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}"
+  service_role = "${aws_iam_role.codebuild_role.arn}"
+
+  "source" {
+    type            = "GITHUB"
+    location        = "https://github.com/nekochans/qiita-stocker-backend.git"
+    git_clone_depth = 1
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/33

# Doneの定義
- CodeDeploy用のリソースが作成されBuildが出来る状態になっている事

# 変更点概要

## 技術的変更点概要
- デプロイ時に必須となるCodeBuildのリソースを作成

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 このPRの内容はさほど重要ではなく、[このPR](https://github.com/nekochans/qiita-stocker-backend/pull/147) の内容と合わせてデプロイ方法の確認を行って欲しい🐱！

# 補足情報
[このPR](https://github.com/nekochans/qiita-stocker-backend/pull/147) と同時にマージする必要がある。

TODOコメントにも書いてあるが `AdministratorAccess` をCodeBuildに付与してある。

本当は望ましくないが、CodeBuildは結構色々なリソースに接続しているので、こうしてある。（時間が出来たら適切な権限に変更するのがセキュリティ的に望ましい）