### PR TITLE
ヘルスチェックのURLを /api/statuses に変更

### DIFF
--- a/modules/aws/api/alb.tf
+++ b/modules/aws/api/alb.tf
@@ -70,7 +70,7 @@ resource "aws_lb_target_group" "api" {
   vpc_id   = "${lookup(var.vpc, "vpc_id")}"
 
   health_check {
-    path                = "/"
+    path                = "/api/statuses"
     timeout             = 5
     healthy_threshold   = 5
     unhealthy_threshold = 2


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/25

# 関連URL
`/api/statuses`

# Doneの定義
- ヘルスチェックのURLが `/api/statuses` に変更されていること

# 変更点概要

## 技術的変更点概要
- ALBのヘルスチェックURLを `/api/statuses` を変更