### PR TITLE
SSHキーの名前を環境毎に一意になるように修正

### DIFF
--- a/modules/aws/api/alb.tf
+++ b/modules/aws/api/alb.tf
@@ -70,7 +70,7 @@ resource "aws_lb_target_group" "api" {
   vpc_id   = "${lookup(var.vpc, "vpc_id")}"
 
   health_check {
-    path                = "/"
+    path                = "/api/statuses"
     timeout             = 5
     healthy_threshold   = 5
     unhealthy_threshold = 2

--- a/modules/aws/api/variable.tf
+++ b/modules/aws/api/variable.tf
@@ -4,7 +4,7 @@ variable "api" {
   default = {
     default.project       = "qiita-stocker"
     default.name          = "api"
-    default.ami           = "ami-00f9d04b3b3092052"
+    default.ami           = "ami-0d7ed3ddb85b521a6"
     default.instance_type = "t2.micro"
     default.volume_type   = "gp2"
     default.volume_size   = "30"

--- a/modules/aws/bastion/main.tf
+++ b/modules/aws/bastion/main.tf
@@ -17,7 +17,7 @@ resource "aws_security_group" "bastion" {
 
 resource "aws_key_pair" "ssh_key_pair" {
   public_key = "${file(var.ssh_public_key_path)}"
-  key_name   = "ssh_key"
+  key_name   = "${terraform.workspace}-ssh-key"
 }
 
 resource "aws_security_group_rule" "ssh_from_workplace" {

--- a/modules/aws/bastion/variable.tf
+++ b/modules/aws/bastion/variable.tf
@@ -3,7 +3,7 @@ variable "bastion" {
 
   default = {
     default.name          = "bastion"
-    default.ami           = "ami-00f9d04b3b3092052"
+    default.ami           = "ami-0d7ed3ddb85b521a6"
     default.instance_type = "t3.micro"
     default.volume_type   = "gp2"
     default.volume_size   = "8"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/29

# Doneの定義
- AWS上のSSHキーペアが環境毎に一意になっていること

# 変更点概要

## 技術的変更点概要
- sshキーの名前に環境変数のprefixを追加
- ついでにAmazonLinux2の新しいAMIイメージが出ていたので、利用するAMIイメージを最新に更新
- Ansibleを適応し最新のアプリケーションをデプロイし正常動作することを確認済
