### PR TITLE
RDSをServerlessから通常のインスタンスに変更

### DIFF
--- a/modules/aws/rds/iam.tf
+++ b/modules/aws/rds/iam.tf
@@ -1,0 +1,22 @@
+data "aws_iam_policy_document" "rds_monitoring" {
+  "statement" {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["monitoring.rds.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "rds_monitoring" {
+  name               = "${terraform.workspace}-rds-monitoring"
+  assume_role_policy = "${data.aws_iam_policy_document.rds_monitoring.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "rds_monitoring" {
+  role       = "${aws_iam_role.rds_monitoring.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -123,16 +123,16 @@ resource "aws_rds_cluster" "rds_cluster" {
   preferred_maintenance_window    = "wed:20:15-wed:20:45"
   db_subnet_group_name            = "${aws_db_subnet_group.rds_subnet_group.name}"
   db_cluster_parameter_group_name = "${aws_rds_cluster_parameter_group.rds_cluster_parameter_group.name}"
-  engine                          = "aurora-mysql"
-  engine_version                  = "5.7.12"
+  engine                          = "${lookup(var.rds, "${terraform.env}.engine", var.rds["default.engine"])}"
+  engine_version                  = "${lookup(var.rds, "${terraform.env}.engine_version", var.rds["default.engine_version"])}"
 }
 
 resource "aws_rds_cluster_instance" "rds_cluster_instance" {
-  count                   = "1"
+  count                   = "${lookup(var.rds, "${terraform.env}.instance_count", var.rds["default.instance_count"])}"
   cluster_identifier      = "${aws_rds_cluster.rds_cluster.id}"
-  instance_class          = "db.t2.small"
-  engine                  = "aurora-mysql"
-  engine_version          = "5.7.12"
+  instance_class          = "${lookup(var.rds, "${terraform.env}.instance_class", var.rds["default.instance_class"])}"
+  engine                  = "${lookup(var.rds, "${terraform.env}.engine", var.rds["default.engine"])}"
+  engine_version          = "${lookup(var.rds, "${terraform.env}.engine_version", var.rds["default.engine_version"])}"
   identifier              = "${lookup(var.rds, "${terraform.env}.name", var.rds["default.name"])}-${count.index}"
   db_subnet_group_name    = "${aws_db_subnet_group.rds_subnet_group.name}"
   db_parameter_group_name = "${aws_db_parameter_group.rds_parameter_group.name}"

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -74,7 +74,7 @@ resource "aws_rds_cluster_parameter_group" "rds_cluster_parameter_group" {
 
   parameter {
     name  = "character_set_filesystem"
-    value = "utf8mb4"
+    value = "binary"
   }
 
   parameter {

--- a/modules/aws/rds/variable.tf
+++ b/modules/aws/rds/variable.tf
@@ -2,8 +2,12 @@ variable "rds" {
   type = "map"
 
   default = {
-    default.name = "prod-database"
-    stg.name     = "stg-database"
+    default.name           = "prod-database"
+    stg.name               = "stg-database"
+    default.engine         = "aurora-mysql"
+    default.engine_version = "5.7.12"
+    default.instance_class = "db.t2.small"
+    default.instance_count = 1
   }
 }
 

--- a/modules/aws/rds/variable.tf
+++ b/modules/aws/rds/variable.tf
@@ -2,7 +2,8 @@ variable "rds" {
   type = "map"
 
   default = {
-    default.name = "database"
+    default.name = "prod-database"
+    stg.name     = "stg-database"
   }
 }
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/32

# Doneの定義
- RDSのClusterが通常のAuroraインスタンスに変更されていること

# 変更点概要

## 仕様的変更点概要
- Serverlessではなく通常のRDSインスタンスからなるAuroraClusterを作成するように変更

本件とは直接関係はないが以下の変更を行ってある。

- RDSのモニタリングを有効化（メモリ、CPU使用率、その他、DBServerの状況が見れるように）

<img width="1037" alt="monitoring" src="https://user-images.githubusercontent.com/11032365/51788591-08b61200-21c3-11e9-8fd5-e0493bb11fd4.png">

- 各種リファクタリング
  - parameterで良く使う文字列を変数として定義するように変更
  - セキュリティグループとセキュリティグループルールを分離（万が一変更があった時にセキュリティグループの再構築を防ぐ為）

## 技術的変更点概要
- `modules/aws/rds/main.tf` を通常のAuroraClusterを作成する内容に変更
- RDSを監視する為のIAMロールを追加