### PR TITLE
メンテナンスモード用のBuildプロジェクトを構築

### DIFF
--- a/modules/aws/api/codebuild.tf
+++ b/modules/aws/api/codebuild.tf
@@ -54,3 +54,30 @@ resource "aws_codebuild_project" "api" {
     git_clone_depth = 1
   }
 }
+
+resource "aws_codebuild_project" "api_maintenance" {
+  "artifacts" {
+    type = "NO_ARTIFACTS"
+  }
+
+  "environment" {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "aws/codebuild/nodejs:10.14.1"
+    type         = "LINUX_CONTAINER"
+
+    environment_variable {
+      name  = "DEPLOY_STAGE"
+      value = "${terraform.workspace}"
+    }
+  }
+
+  name         = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}-maintenance"
+  service_role = "${aws_iam_role.codebuild_role.arn}"
+
+  "source" {
+    type            = "GITHUB"
+    location        = "https://github.com/nekochans/qiita-stocker-backend.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec-maintenance.yml"
+  }
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/36

# Doneの定義
- メンテナンスモード用のBuildプロジェクトが作成されていること

# スクリーンショット
正常にメンテナンスモードへ移行する事を確認済。

![evidence](https://user-images.githubusercontent.com/11032365/53300662-c3eacd00-388d-11e9-983b-b9e89d2823f9.png)

# 変更点概要

## 技術的変更点概要
`aws_codebuild_project` を使ってBuildプロジェクトを作成、内容は通常のBuildプロジェクト（`aws_codebuild_project.api`）とほぼ同じだが、参照する設定ファイルが https://github.com/nekochans/qiita-stocker-backend/pull/169 で作成した `buildspec-maintenance.yml` になっている点が異なる。

# 補足情報

## メンテナンスモードへの移行方法
Buildプロジェクト `stg-api-maintenance` を実行する

CodeDeployでBuildされたプロジェクトをデプロイする

## メンテナンスモードの解除方法
Buildプロジェクト `stg-api` を実行する

CodeDeployでBuildされたプロジェクトをデプロイする