### PR TITLE
ALBのプロトコルをhttpsに変更する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ providers/aws/environments/20-bastion/terraform.tfvars
 providers/aws/environments/21-api/terraform.tfvars
 providers/aws/environments/22-frontend/terraform.tfvars
 providers/aws/environments/23-rds/terraform.tfvars
+providers/aws/environments/25-ecs/terraform.tfvars
 
 # Node.js
 node_modules

--- a/modules/aws/ecs/task/api.json
+++ b/modules/aws/ecs/task/api.json
@@ -19,6 +19,12 @@
     "memory": 300,
     "essential": true,
     "links": ["php"],
+    "environment": [
+      {
+        "name": "PHP_HOST",
+        "value": "php"
+      }
+    ],
     "portMappings": [
       {
         "containerPort": 80,

--- a/modules/aws/ecs/variable.tf
+++ b/modules/aws/ecs/variable.tf
@@ -31,3 +31,22 @@ variable "rds" {
 
   default = {}
 }
+
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}
+
+variable "sub_domain_name" {
+  type = "map"
+
+  default = {
+    stg.name     = "stg-ecs-api"
+    default.name = "ecs-api"
+  }
+}
+
+data "aws_acm_certificate" "main" {
+  domain = "*.${var.main_domain_name}"
+}

--- a/providers/aws/environments/25-ecs/main.tf
+++ b/providers/aws/environments/25-ecs/main.tf
@@ -1,6 +1,7 @@
 module "ecs" {
-  source = "../../../../modules/aws/ecs"
-  vpc    = "${data.terraform_remote_state.network.vpc}"
-  ecr    = "${data.terraform_remote_state.ecr.ecr}"
-  rds    = "${data.terraform_remote_state.rds.rds}"
+  source           = "../../../../modules/aws/ecs"
+  vpc              = "${data.terraform_remote_state.network.vpc}"
+  ecr              = "${data.terraform_remote_state.ecr.ecr}"
+  rds              = "${data.terraform_remote_state.rds.rds}"
+  main_domain_name = "${var.main_domain_name}"
 }

--- a/providers/aws/environments/25-ecs/variable.tf
+++ b/providers/aws/environments/25-ecs/variable.tf
@@ -1,0 +1,5 @@
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}

--- a/scripts/createTerraformConfig.ts
+++ b/scripts/createTerraformConfig.ts
@@ -14,7 +14,8 @@ import {
   createBastionTfvars,
   createApiTfvars,
   createFrontendTfvars,
-  createRdsTfvars
+  createRdsTfvars,
+  createEcsTfvars
 } from "./createTfvars";
 import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
 
@@ -45,6 +46,7 @@ import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
   await createApiTfvars(deployStage);
   await createFrontendTfvars(deployStage);
   await createRdsTfvars(deployStage);
+  await createEcsTfvars(deployStage);
 
   return Promise.resolve();
 })().catch((error: Error) => {

--- a/scripts/createTfvars.ts
+++ b/scripts/createTfvars.ts
@@ -96,3 +96,19 @@ export const createRdsTfvars = async (deployStage: string): Promise<void> => {
 
   await createEnvFile(params);
 };
+
+export const createEcsTfvars = async (deployStage: string): Promise<void> => {
+  const params = {
+    region: AwsRegion.ap_northeast_1,
+    profile: awsProfileName(deployStage),
+    type: EnvFileType.terraform,
+    outputDir: "./providers/aws/environments/25-ecs/",
+    secretIds: secretIds(deployStage),
+    outputWhitelist: ["MAIN_DOMAIN_NAME"],
+    keyMapping: {
+      MAIN_DOMAIN_NAME: "main_domain_name"
+    }
+  };
+
+  await createEnvFile(params);
+};


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/51

# Doneの定義
- ECSコンテナにHTTPSで通信できること
- タスクの定義で、環境変数が設定されていること(https://github.com/nekochans/qiita-stocker-backend/pull/175 この対応で環境変数の設定が必要になったため)

# 変更点概要

## 技術的変更点概要
- Route53にAレコードを追加し、ALBのプロトコルをHTTPSに変更
- Nginxのタスクの定義に環境変数を追加