### PR TITLE
Fargateのリソースを作成する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ providers/aws/environments/21-api/terraform.tfvars
 providers/aws/environments/22-frontend/terraform.tfvars
 providers/aws/environments/23-rds/terraform.tfvars
 providers/aws/environments/25-ecs/terraform.tfvars
+providers/aws/environments/26-fargate/terraform.tfvars
 
 # Node.js
 node_modules

--- a/modules/aws/fargate/alb.tf
+++ b/modules/aws/fargate/alb.tf
@@ -1,0 +1,113 @@
+resource "aws_security_group" "fargate_api_alb" {
+  name        = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb"
+  description = "Security Group to ${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb"
+  vpc_id      = "${lookup(var.vpc, "vpc_id")}"
+
+  tags {
+    Name = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "fargate_api_alb" {
+  security_group_id = "${aws_security_group.fargate_api_alb.id}"
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_s3_bucket" "fargate_api_alb_logs" {
+  bucket        = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb-logs"
+  force_destroy = true
+}
+
+data "aws_iam_policy_document" "put_fargate_api_alb_logs_policy" {
+  "statement" {
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.fargate_api_alb_logs.arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${data.aws_elb_service_account.aws_elb_service_account.id}"]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "fargate_api" {
+  bucket = "${aws_s3_bucket.fargate_api_alb_logs.id}"
+  policy = "${data.aws_iam_policy_document.put_fargate_api_alb_logs_policy.json}"
+}
+
+resource "aws_alb" "fargate_alb" {
+  name                       = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = ["${aws_security_group.fargate_api_alb.id}"]
+  subnets                    = ["${var.vpc["subnet_public_1a_id"]}", "${var.vpc["subnet_public_1c_id"]}", "${var.vpc["subnet_public_1d_id"]}"]
+  enable_deletion_protection = false
+
+  access_logs {
+    enabled = true
+    bucket  = "${aws_s3_bucket.fargate_api_alb_logs.bucket}"
+  }
+
+  tags {
+    Name = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb"
+  }
+}
+
+resource "aws_alb_target_group" "fargate" {
+  name     = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  port     = 80
+  protocol = "HTTP"
+  vpc_id   = "${lookup(var.vpc, "vpc_id")}"
+
+  health_check {
+    path                = "/api/statuses"
+    timeout             = 5
+    healthy_threshold   = 5
+    unhealthy_threshold = 2
+    interval            = 20
+    matcher             = 200
+  }
+
+  target_type = "ip"
+}
+
+resource "aws_alb_listener" "fargate_alb" {
+  load_balancer_arn = "${aws_alb.fargate_alb.id}"
+  port              = 443
+  protocol          = "HTTPS"
+
+  ssl_policy      = "ELBSecurityPolicy-2016-08"
+  certificate_arn = "${data.aws_acm_certificate.main.arn}"
+
+  default_action {
+    target_group_arn = "${aws_alb_target_group.fargate.id}"
+    type             = "forward"
+  }
+}
+
+data "aws_route53_zone" "fargate_api" {
+  name = "${var.main_domain_name}"
+}
+
+resource "aws_route53_record" "fargate_api" {
+  zone_id = "${data.aws_route53_zone.fargate_api.zone_id}"
+  name    = "${lookup(var.sub_domain_name, "${terraform.env}.name", var.sub_domain_name["default.name"])}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_alb.fargate_alb.dns_name}"
+    zone_id                = "${aws_alb.fargate_alb.zone_id}"
+    evaluate_target_health = false
+  }
+}

--- a/modules/aws/fargate/alb.tf
+++ b/modules/aws/fargate/alb.tf
@@ -1,10 +1,10 @@
 resource "aws_security_group" "fargate_api_alb" {
-  name        = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb"
-  description = "Security Group to ${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb"
+  name        = "${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}-alb"
+  description = "Security Group to ${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}-alb"
   vpc_id      = "${lookup(var.vpc, "vpc_id")}"
 
   tags {
-    Name = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb"
+    Name = "${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}-alb"
   }
 
   egress {
@@ -25,7 +25,7 @@ resource "aws_security_group_rule" "fargate_api_alb" {
 }
 
 resource "aws_s3_bucket" "fargate_api_alb_logs" {
-  bucket        = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb-logs"
+  bucket        = "${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}-alb-logs"
   force_destroy = true
 }
 
@@ -47,7 +47,7 @@ resource "aws_s3_bucket_policy" "fargate_api" {
 }
 
 resource "aws_alb" "fargate_alb" {
-  name                       = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  name                       = "${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}"
   internal                   = false
   load_balancer_type         = "application"
   security_groups            = ["${aws_security_group.fargate_api_alb.id}"]
@@ -60,12 +60,12 @@ resource "aws_alb" "fargate_alb" {
   }
 
   tags {
-    Name = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}-alb"
+    Name = "${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}-alb"
   }
 }
 
 resource "aws_alb_target_group" "fargate" {
-  name     = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  name     = "${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}"
   port     = 80
   protocol = "HTTP"
   vpc_id   = "${lookup(var.vpc, "vpc_id")}"

--- a/modules/aws/fargate/iam.tf
+++ b/modules/aws/fargate/iam.tf
@@ -1,0 +1,23 @@
+data "aws_iam_policy_document" "trust_relationship" {
+  "statement" {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "task_execution_role" {
+  name               = "${terraform.workspace}-task-execution-role"
+  assume_role_policy = "${data.aws_iam_policy_document.trust_relationship.json}"
+}
+
+resource "aws_iam_policy_attachment" "task_execution_role_attach" {
+  name       = "ecs-task-role-attach"
+  roles      = ["${aws_iam_role.task_execution_role.name}"]
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}

--- a/modules/aws/fargate/main.tf
+++ b/modules/aws/fargate/main.tf
@@ -1,0 +1,101 @@
+resource "aws_security_group" "fargate_api" {
+  name        = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  description = "Security Group to ${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  vpc_id      = "${lookup(var.vpc, "vpc_id")}"
+
+  tags {
+    Name = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group_rule" "fargate_api_from_alb" {
+  security_group_id        = "${aws_security_group.fargate_api.id}"
+  type                     = "ingress"
+  from_port                = "80"
+  to_port                  = "80"
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.fargate_api_alb.id}"
+}
+
+resource "aws_security_group_rule" "rds_from_fargate_api_server" {
+  security_group_id        = "${lookup(var.rds, "rds_security_id")}"
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = "${aws_security_group.fargate_api.id}"
+}
+
+resource "aws_cloudwatch_log_group" "fargate_api" {
+  name = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+}
+
+data "template_file" "user_data" {
+  template = "${file("../../../../modules/aws/fargate/user-data/userdata.sh")}"
+
+  vars {
+    cluster_name = "${aws_ecs_cluster.api_fargate_cluster.name}"
+  }
+}
+
+resource "aws_ecs_cluster" "api_fargate_cluster" {
+  name = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+}
+
+data "template_file" "api_fargate_template_file" {
+  template = "${file("../../../../modules/aws/fargate/task/api.json")}"
+
+  vars {
+    aws_region      = "${lookup(var.ecs, "region")}"
+    php_image_url   = "${element(var.ecr["php_image_url"], 0)}"
+    nginx_image_url = "${element(var.ecr["nginx_image_url"], 0)}"
+    aws_logs_group  = "${aws_cloudwatch_log_group.fargate_api.name}"
+  }
+}
+
+resource "aws_ecs_task_definition" "api_fargate" {
+  family                   = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  network_mode             = "awsvpc"
+  container_definitions    = "${data.template_file.api_fargate_template_file.rendered}"
+  cpu                      = 256
+  memory                   = 512
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = "${aws_iam_role.task_execution_role.arn}"
+
+  depends_on = [
+    "aws_cloudwatch_log_group.fargate_api",
+  ]
+}
+
+resource "aws_ecs_service" "api_ecs_service" {
+  name            = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
+  cluster         = "${aws_ecs_cluster.api_fargate_cluster.id}"
+  task_definition = "${aws_ecs_task_definition.api_fargate.arn}"
+  desired_count   = 1
+  launch_type     = "FARGATE"
+
+  load_balancer {
+    target_group_arn = "${aws_alb_target_group.fargate.id}"
+    container_name   = "nginx"
+    container_port   = 80
+  }
+
+  network_configuration {
+    subnets = ["${var.vpc["subnet_private_1a_id"]}", "${var.vpc["subnet_private_1c_id"]}", "${var.vpc["subnet_private_1d_id"]}"]
+
+    security_groups = [
+      "${aws_security_group.fargate_api.id}",
+    ]
+  }
+
+  depends_on = [
+    "aws_alb_listener.fargate_alb",
+  ]
+}

--- a/modules/aws/fargate/task/api.json
+++ b/modules/aws/fargate/task/api.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "php",
+    "image": "${php_image_url}",
+    "memory": 300,
+    "essential": true,
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_logs_group}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    }
+  },
+  {
+    "name": "nginx",
+    "image": "${nginx_image_url}",
+    "memory": 300,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 80,
+        "hostPort": 80,
+        "protocol": "tcp"
+      }
+    ],
+    "logConfiguration": {
+      "logDriver": "awslogs",
+      "options": {
+        "awslogs-group": "${aws_logs_group}",
+        "awslogs-region": "${aws_region}",
+        "awslogs-stream-prefix": "ecs"
+      }
+    }
+  }
+]

--- a/modules/aws/fargate/user-data/userdata.sh
+++ b/modules/aws/fargate/user-data/userdata.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cat << EOT >> /etc/ecs/ecs.config
+ECS_CLUSTER=${cluster_name}
+EOT

--- a/modules/aws/fargate/variable.tf
+++ b/modules/aws/fargate/variable.tf
@@ -1,0 +1,48 @@
+variable "ecs" {
+  type = "map"
+
+  default = {
+    default.name = "prod-fargate-api"
+    stg.name     = "stg-fargate-api"
+    region       = "ap-northeast-1"
+  }
+}
+
+data "aws_elb_service_account" "aws_elb_service_account" {}
+
+variable "vpc" {
+  type = "map"
+
+  default = {}
+}
+
+variable "ecr" {
+  type = "map"
+
+  default = {}
+}
+
+variable "rds" {
+  type = "map"
+
+  default = {}
+}
+
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}
+
+variable "sub_domain_name" {
+  type = "map"
+
+  default = {
+    stg.name     = "stg-fargate-api"
+    default.name = "fargate-api"
+  }
+}
+
+data "aws_acm_certificate" "main" {
+  domain = "*.${var.main_domain_name}"
+}

--- a/modules/aws/fargate/variable.tf
+++ b/modules/aws/fargate/variable.tf
@@ -1,4 +1,4 @@
-variable "ecs" {
+variable "fargate" {
   type = "map"
 
   default = {

--- a/providers/aws/environments/26-fargate/main.tf
+++ b/providers/aws/environments/26-fargate/main.tf
@@ -1,0 +1,7 @@
+module "fargate" {
+  source           = "../../../../modules/aws/fargate"
+  vpc              = "${data.terraform_remote_state.network.vpc}"
+  ecr              = "${data.terraform_remote_state.ecr.ecr}"
+  rds              = "${data.terraform_remote_state.rds.rds}"
+  main_domain_name = "${var.main_domain_name}"
+}

--- a/providers/aws/environments/26-fargate/variable.tf
+++ b/providers/aws/environments/26-fargate/variable.tf
@@ -1,0 +1,5 @@
+variable "main_domain_name" {
+  type = "string"
+
+  default = ""
+}

--- a/scripts/createBackend.ts
+++ b/scripts/createBackend.ts
@@ -9,6 +9,7 @@ import {
   rdsOutputPath,
   ecrOutputPath,
   ecsOutputPath,
+  fargateOutputPath,
   terraformVersion,
   tfstateBucketName,
   tfstateBucketRegion
@@ -177,6 +178,42 @@ export const createEcsBackend = async (deployStage: string): Promise<void> => {
       backend: {
         bucket: tfstateBucketName(deployStage),
         key: "ecs/terraform.tfstate",
+        region: tfstateBucketRegion(),
+        profile: awsProfileName(deployStage)
+      }
+    },
+    remoteStateList: [
+      networkRemoteState(deployStage),
+      {
+        name: "rds",
+        bucket: tfstateBucketName(deployStage),
+        key: "env:/${terraform.env}/rds/terraform.tfstate",
+        region: tfstateBucketRegion(),
+        profile: awsProfileName(deployStage)
+      },
+      {
+        name: "ecr",
+        bucket: tfstateBucketName(deployStage),
+        key: "env:/${terraform.env}/ecr/terraform.tfstate",
+        region: tfstateBucketRegion(),
+        profile: awsProfileName(deployStage)
+      }
+    ]
+  };
+
+  await createS3Backend(params);
+};
+
+export const createFargateBackend = async (
+  deployStage: string
+): Promise<void> => {
+  const params = {
+    outputPath: fargateOutputPath(),
+    backendParams: {
+      requiredVersion: terraformVersion(),
+      backend: {
+        bucket: tfstateBucketName(deployStage),
+        key: "fargate/terraform.tfstate",
         region: tfstateBucketRegion(),
         profile: awsProfileName(deployStage)
       }

--- a/scripts/createTerraformConfig.ts
+++ b/scripts/createTerraformConfig.ts
@@ -6,7 +6,8 @@ import {
   createFrontendBackend,
   createRdsBackend,
   createEcrBackend,
-  createEcsBackend
+  createEcsBackend,
+  createFargateBackend
 } from "./createBackend";
 import createProvider from "./createProvider";
 import {
@@ -15,7 +16,8 @@ import {
   createApiTfvars,
   createFrontendTfvars,
   createRdsTfvars,
-  createEcsTfvars
+  createEcsTfvars,
+  createFargateTfvars
 } from "./createTfvars";
 import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
 
@@ -35,6 +37,7 @@ import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
   await createRdsBackend(deployStage);
   await createEcrBackend(deployStage);
   await createEcsBackend(deployStage);
+  await createFargateBackend(deployStage);
 
   const targetDirs = outputPathList();
   targetDirs.forEach(async (dir: string) => {
@@ -47,6 +50,7 @@ import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
   await createFrontendTfvars(deployStage);
   await createRdsTfvars(deployStage);
   await createEcsTfvars(deployStage);
+  await createFargateTfvars(deployStage);
 
   return Promise.resolve();
 })().catch((error: Error) => {

--- a/scripts/createTfvars.ts
+++ b/scripts/createTfvars.ts
@@ -112,3 +112,22 @@ export const createEcsTfvars = async (deployStage: string): Promise<void> => {
 
   await createEnvFile(params);
 };
+
+export const createFargateTfvars = async (
+  deployStage: string
+): Promise<void> => {
+  const params = {
+    region: AwsRegion.ap_northeast_1,
+    profile: awsProfileName(deployStage),
+    type: EnvFileType.terraform,
+    outputDir: "./providers/aws/environments/26-fargate/",
+    secretIds: secretIds(deployStage),
+    outputWhitelist: ["MAIN_DOMAIN_NAME"],
+    keyMapping: {
+      MAIN_DOMAIN_NAME: "main_domain_name"
+    }
+  };
+
+  await createEnvFile(params);
+};
+createFargateTfvars;

--- a/scripts/terraformConfigUtil.ts
+++ b/scripts/terraformConfigUtil.ts
@@ -46,6 +46,10 @@ export const ecsOutputPath = (): string => {
   return "./providers/aws/environments/25-ecs/";
 };
 
+export const fargateOutputPath = (): string => {
+  return "./providers/aws/environments/26-fargate/";
+};
+
 export const outputPathList = (): string[] => {
   return [
     networkOutputPath(),
@@ -55,7 +59,8 @@ export const outputPathList = (): string[] => {
     frontendOutputPath(),
     rdsOutputPath(),
     ecrOutputPath(),
-    ecsOutputPath()
+    ecsOutputPath(),
+    fargateOutputPath()
   ];
 };
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/53

# Doneの定義
https://github.com/nekochans/qiita-stocker-terraform/issues/53 の完了条件が満たされていること

# 変更点概要

## 技術的変更点概要
Fargateのリソースを作成。EC2モードとの違いは下記の通り。

- IAMロールの作成
  - ECSタスクの実行権限を付与したIAMロールを作成

- ALB
  - EC2モードと別のドメインにするために新規で作成
  - ターゲットグループの`target_type`は`ip`を設定(EC2モードは`instance`)

- タスクの定義 (aws_ecs_task_definition)
  - 以下の設定を追加
 ```
 network_mode    = "awsvpc"
 cpu = 256	
 memory = 512	
 requires_compatibilities = ["FARGATE"]	
 execution_role_arn = "${aws_iam_role.task_execution_role.arn}"
  ```

- コンテナの定義
  - linksの設定を削除(ネットワークが`awsvpc`のため使用不可)
  - 環境変数の設定を削除(https://github.com/nekochans/qiita-stocker-backend/pull/175 で対応したDockerfile内で定義してある環境変数を使用する)

- サービス(aws_ecs_service)
  - `launch_type`にFARGATEを設定
  - `network_configuration`を追加
  - IAMロールの設定を削除