### PR TITLE
Migrationを行う為のCodeBuildプロジェクトを作成

### DIFF
--- a/modules/aws/api/codebuild.tf
+++ b/modules/aws/api/codebuild.tf
@@ -81,3 +81,58 @@ resource "aws_codebuild_project" "api_maintenance" {
     buildspec       = "buildspec-maintenance.yml"
   }
 }
+
+resource "aws_security_group" "api_codebuild" {
+  name        = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}-codebuild"
+  description = "Security Group to ${lookup(var.api, "${terraform.env}.name", var.api["default.name"])} codebuild"
+  vpc_id      = "${lookup(var.vpc, "vpc_id")}"
+
+  tags {
+    Name = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_codebuild_project" "api_rds_migration" {
+  "artifacts" {
+    type = "NO_ARTIFACTS"
+  }
+
+  "environment" {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "nekochans/laravel-build:0.2.0"
+    type         = "LINUX_CONTAINER"
+
+    environment_variable {
+      name  = "DEPLOY_STAGE"
+      value = "${terraform.workspace}"
+    }
+  }
+
+  name         = "${terraform.workspace}-${lookup(var.api, "${terraform.env}.name", var.api["default.name"])}-rds-migration"
+  service_role = "${aws_iam_role.codebuild_role.arn}"
+
+  "source" {
+    type            = "GITHUB"
+    location        = "https://github.com/nekochans/qiita-stocker-backend.git"
+    git_clone_depth = 1
+    buildspec       = "buildspec-migration.yml"
+  }
+
+  vpc_config {
+    security_group_ids = ["${aws_security_group.api_codebuild.id}"]
+
+    subnets = [
+      "${var.vpc["subnet_private_1a_id"]}",
+      "${var.vpc["subnet_private_1c_id"]}",
+    ]
+
+    vpc_id = "${lookup(var.vpc, "vpc_id")}"
+  }
+}

--- a/modules/aws/api/output.tf
+++ b/modules/aws/api/output.tf
@@ -1,7 +1,8 @@
 output "api" {
   value = "${
     map(
-      "api_security_id", "${aws_security_group.api.id}"
+      "api_security_id", "${aws_security_group.api.id}",
+      "api_codebuild_security_id", "${aws_security_group.api_codebuild.id}"
     )
   }"
 }

--- a/modules/aws/rds/main.tf
+++ b/modules/aws/rds/main.tf
@@ -24,6 +24,15 @@ resource "aws_security_group_rule" "rds_from_api_server" {
   source_security_group_id = "${lookup(var.api, "api_security_id")}"
 }
 
+resource "aws_security_group_rule" "rds_from_api_codebuild" {
+  security_group_id        = "${aws_security_group.rds_cluster.id}"
+  type                     = "ingress"
+  from_port                = "3306"
+  to_port                  = "3306"
+  protocol                 = "tcp"
+  source_security_group_id = "${lookup(var.api, "api_codebuild_security_id")}"
+}
+
 resource "aws_db_subnet_group" "rds_subnet_group" {
   name        = "${lookup(var.rds, "${terraform.env}.name", var.rds["default.name"])}"
   description = "${lookup(var.rds, "${terraform.env}.name", var.rds["default.name"])}-subnet-group"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/48

# Doneの定義
- Migrationを実行するだけのBuildプロジェクトが作成されている事

# スクリーンショット
以下のように正常にBuildが通る事を確認済。

<img width="703" alt="evidence" src="https://user-images.githubusercontent.com/11032365/54265088-dc5e2580-45b7-11e9-8734-fceb19d1d614.png">

# 変更点概要

## 仕様的変更点概要
- VPCの中にCodeBuildプロジェクトを作成しRDSにアクセス可能にした上でMigrationコマンドを実行するプロジェクトを作成

## 技術的変更点概要
https://github.com/nekochans/qiita-stocker-docker/pull/6 のDockerイメージを使って、Buildプロジェクトを動作させる https://github.com/nekochans/qiita-stocker-backend/pull/179 がその設定ファイル。

# 補足情報
このPRは以下の2つのPRと依存関係になっている。

- https://github.com/nekochans/qiita-stocker-backend/pull/179
- https://github.com/nekochans/qiita-stocker-docker/pull/6