### PR TITLE
VPCフローログを有効化

### DIFF
--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -8,6 +8,59 @@ resource "aws_vpc" "vpc" {
   }
 }
 
+data "aws_iam_policy_document" "vpc_flow_log_trust_relationship" {
+  "statement" {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["vpc-flow-logs.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "vpc_flow_log_policy" {
+  "statement" {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "vpc_flow_log_role" {
+  name               = "${terraform.workspace}-vpc-flow-log-role"
+  assume_role_policy = "${data.aws_iam_policy_document.vpc_flow_log_trust_relationship.json}"
+}
+
+resource "aws_iam_role_policy" "vpc_flow_logs_role" {
+  role   = "${aws_iam_role.vpc_flow_log_role.name}"
+  policy = "${data.aws_iam_policy_document.vpc_flow_log_policy.json}"
+}
+
+resource "aws_cloudwatch_log_group" "vpc_flow_log" {
+  name              = "${terraform.workspace}-vpc-flow-log"
+  retention_in_days = 30
+}
+
+resource "aws_flow_log" "vpc_flow_log" {
+  iam_role_arn    = "${aws_iam_role.vpc_flow_log_role.arn}"
+  log_destination = "${aws_cloudwatch_log_group.vpc_flow_log.arn}"
+  traffic_type    = "REJECT"
+  vpc_id          = "${aws_vpc.vpc.id}"
+}
+
 resource "aws_internet_gateway" "igw" {
   vpc_id = "${aws_vpc.vpc.id}"
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/24

# Doneの定義
- VPCFlowログが出力されるようになっている事

# スクリーンショット
CloudWatchLogに以下の形で出力するように設定

![VPCLog](https://user-images.githubusercontent.com/11032365/54291798-780b8800-45f0-11e9-9de2-d9cc1b83290a.png)

# 変更点概要

## 技術的変更点概要
- traffic_typeが `REJECT` つまり通信が失敗したログのみを出力するように設定（もしALLにするとすごい数になる）

https://www.terraform.io/docs/providers/aws/r/flow_log.html#traffic_type

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 一応ログは通信失敗時のみ出るようにしているのと、CloudWatchLogの有効期限を30日に設定してあるよ🐱！（保存期間を無限にするとCloudWatchLogの料金が高くなる）

これでちょっと様子を見るけどもし、料金が高くなってきたら、ちょっと設定を見直すかも・・・

https://www.terraform.io/docs/providers/aws/r/flow_log.html#traffic_type

例えば [公式ドキュメント S3Logging](https://www.terraform.io/docs/providers/aws/r/flow_log.html#s3-logging) に載っているみたいに保存先をS3Bucketにすれば料金は抑えられると思う👍

※ ただし別途S3Bucketからログを検索出来る仕組みの構築が必要になると思う！