### PR TITLE
AWS Fargateのデプロイを行う為のリソースを作成する

### DIFF
--- a/modules/aws/fargate/codedeploy.tf
+++ b/modules/aws/fargate/codedeploy.tf
@@ -1,0 +1,100 @@
+data "aws_iam_policy_document" "codedeploy_trust_relationship" {
+  "statement" {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "codedeploy.amazonaws.com",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "codedeploy_policy" {
+  "statement" {
+    effect = "Allow"
+
+    actions = ["iam:PassRole"]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "codedeploy_role" {
+  name               = "${terraform.workspace}-fargate-codedeploy-role"
+  assume_role_policy = "${data.aws_iam_policy_document.codedeploy_trust_relationship.json}"
+}
+
+resource "aws_iam_role_policy" "codedeploy" {
+  name   = "${terraform.workspace}-fargate-codedeploy"
+  role   = "${aws_iam_role.codedeploy_role.id}"
+  policy = "${data.aws_iam_policy_document.codedeploy_policy.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "codedeploy_role" {
+  role       = "${aws_iam_role.codedeploy_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole"
+}
+
+resource "aws_iam_role_policy_attachment" "codedeploy_role_ecs" {
+  role       = "${aws_iam_role.codedeploy_role.name}"
+  policy_arn = "arn:aws:iam::aws:policy/AWSCodeDeployRoleForECSLimited"
+}
+
+resource "aws_codedeploy_app" "fargate_api" {
+  compute_platform = "ECS"
+  name             = "${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}"
+}
+
+resource "aws_codedeploy_deployment_group" "fargate_api_blue_green_deploy" {
+  app_name               = "${aws_codedeploy_app.fargate_api.name}"
+  deployment_group_name  = "blue-green"
+  service_role_arn       = "${aws_iam_role.codedeploy_role.arn}"
+  deployment_config_name = "CodeDeployDefault.ECSAllAtOnce"
+
+  auto_rollback_configuration {
+    enabled = true
+    events  = ["DEPLOYMENT_FAILURE"]
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action                           = "TERMINATE"
+      termination_wait_time_in_minutes = "1"
+    }
+  }
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type   = "BLUE_GREEN"
+  }
+
+  ecs_service {
+    cluster_name = "${aws_ecs_cluster.api_fargate_cluster.name}"
+    service_name = "${aws_ecs_service.api_fargate_service.name}"
+  }
+
+  load_balancer_info {
+    target_group_pair_info {
+      prod_traffic_route {
+        listener_arns = ["${aws_alb_listener.fargate_alb.arn}"]
+      }
+
+      target_group {
+        name = "${aws_alb_target_group.fargate_api_blue.name}"
+      }
+
+      target_group {
+        name = "${aws_alb_target_group.fargate_api_green.name}"
+      }
+    }
+  }
+}

--- a/modules/aws/fargate/main.tf
+++ b/modules/aws/fargate/main.tf
@@ -74,7 +74,7 @@ resource "aws_ecs_task_definition" "api_fargate" {
   ]
 }
 
-resource "aws_ecs_service" "api_ecs_service" {
+resource "aws_ecs_service" "api_fargate_service" {
   name            = "${lookup(var.fargate, "${terraform.env}.name", var.fargate["default.name"])}"
   cluster         = "${aws_ecs_cluster.api_fargate_cluster.id}"
   task_definition = "${aws_ecs_task_definition.api_fargate.arn}"
@@ -82,7 +82,7 @@ resource "aws_ecs_service" "api_ecs_service" {
   launch_type     = "FARGATE"
 
   load_balancer {
-    target_group_arn = "${aws_alb_target_group.fargate.id}"
+    target_group_arn = "${aws_alb_target_group.fargate_api_blue.id}"
     container_name   = "nginx"
     container_port   = 80
   }
@@ -92,6 +92,17 @@ resource "aws_ecs_service" "api_ecs_service" {
 
     security_groups = [
       "${aws_security_group.fargate_api.id}",
+    ]
+  }
+
+  deployment_controller {
+    type = "CODE_DEPLOY"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      "task_definition",
+      "load_balancer",
     ]
   }
 

--- a/scripts/createProvider.ts
+++ b/scripts/createProvider.ts
@@ -13,7 +13,7 @@ const createProvider = async (
     outputPath,
     awsProviderParams: [
       {
-        version: "=1.49.0",
+        version: "=2.2.0",
         region,
         profile: awsProfileName(deployStage)
       }


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/62

# Doneの定義
https://github.com/nekochans/qiita-stocker-terraform/issues/62 の完了条件が満たされていること

# 変更点概要

## 仕様的変更点概要
FargateのBlue/Greenデプロイを行うためのリソースを追加。

## 技術的変更点概要
リソースの変更点は下記の通り。
- ECSサービスの`deployment_controller`のタイプに`CODE_DEPLOY`を追加し、CodeDeployを利用したデプロイができるように設定
- CodeDeploy用のIAMロールを作成 
- CodeDeployアプリケーションとデプロイグループを作成
- ALBのターゲットグループを追加
(Blue/Greenデプロイを行う際に、ALBリスナーのターゲットグループを切り替えるため)

なお、ECS Blue/Green DeploymentがTerraformProviderのバージョン`1.50.0`で対応されたため、バージョンを`1.49.0`から最新の`2.2.0`に変更している。

https://github.com/terraform-providers/terraform-provider-aws/blob/master/CHANGELOG.md#1500-november-29-2018