### PR TITLE
NAT Instanceを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ qiita-stocker-terraform.iml
 dev-qiita-stocker-terraform.iml
 prod-qiita-stocker-terraform.iml
 
+providers/aws/environments/10-network/terraform.tfvars
 providers/aws/environments/11-acm/terraform.tfvars
 providers/aws/environments/20-bastion/terraform.tfvars
 providers/aws/environments/21-api/terraform.tfvars

--- a/modules/aws/vpc/main.tf
+++ b/modules/aws/vpc/main.tf
@@ -161,8 +161,8 @@ resource "aws_route_table" "private" {
   vpc_id = "${aws_vpc.vpc.id}"
 
   route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = "${aws_nat_gateway.nat_1a.id}"
+    cidr_block  = "0.0.0.0/0"
+    instance_id = "${aws_instance.nat_instance_1c.id}"
   }
 
   tags {

--- a/modules/aws/vpc/nat-instance.tf
+++ b/modules/aws/vpc/nat-instance.tf
@@ -1,0 +1,101 @@
+resource "aws_security_group" "nat_instance" {
+  name        = "${lookup(var.nat_instance, "${terraform.env}.name", var.nat_instance["default.name"])}"
+  description = "Security Group to ${lookup(var.nat_instance, "${terraform.env}.name", var.nat_instance["default.name"])}"
+  vpc_id      = "${aws_vpc.vpc.id}"
+
+  tags {
+    Name = "${lookup(var.nat_instance, "${terraform.env}.name", var.nat_instance["default.name"])}"
+  }
+
+  ingress {
+    from_port   = 22
+    protocol    = "tcp"
+    to_port     = 22
+    cidr_blocks = ["${aws_vpc.vpc.cidr_block}"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_key_pair" "nat_ssh_key_pair" {
+  public_key = "${file(var.ssh_public_key_path)}"
+  key_name   = "${terraform.workspace}-nat-ssh-key"
+}
+
+data "aws_iam_policy_document" "nat_instance_trust_relationship" {
+  "statement" {
+    effect = "Allow"
+
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "nat_instance_policy" {
+  "statement" {
+    effect = "Allow"
+
+    actions = [
+      "cloudwatch:PutMetricData",
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:ListMetrics",
+      "ec2:DescribeTags",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role" "nat_instance_role" {
+  name               = "${terraform.workspace}-nat-instance-default-role"
+  assume_role_policy = "${data.aws_iam_policy_document.nat_instance_trust_relationship.json}"
+}
+
+resource "aws_iam_role_policy" "nat_instance_role_policy" {
+  name   = "${terraform.workspace}-nat-instance-role-policy"
+  role   = "${aws_iam_role.nat_instance_role.id}"
+  policy = "${data.aws_iam_policy_document.nat_instance_policy.json}"
+}
+
+resource "aws_iam_instance_profile" "nat_instance_profile" {
+  name = "${terraform.workspace}-nat-instance-profile"
+  role = "${aws_iam_role.nat_instance_role.name}"
+}
+
+resource "aws_instance" "nat_instance_1c" {
+  ami                         = "${lookup(var.nat_instance, "${terraform.env}.ami", var.nat_instance["default.ami"])}"
+  associate_public_ip_address = true
+  instance_type               = "${lookup(var.nat_instance, "${terraform.env}.instance_type", var.nat_instance["default.instance_type"])}"
+
+  ebs_block_device {
+    device_name = "/dev/xvda"
+    volume_type = "${lookup(var.nat_instance, "${terraform.env}.volume_type", var.nat_instance["default.volume_type"])}"
+    volume_size = "${lookup(var.nat_instance, "${terraform.env}.volume_size", var.nat_instance["default.volume_size"])}"
+  }
+
+  key_name               = "${aws_key_pair.nat_ssh_key_pair.id}"
+  subnet_id              = "${aws_subnet.public_1c.id}"
+  vpc_security_group_ids = ["${aws_security_group.nat_instance.id}"]
+
+  tags {
+    Name = "${lookup(var.nat_instance, "${terraform.env}.name", var.nat_instance["default.name"])}-1c"
+  }
+
+  iam_instance_profile = "${aws_iam_instance_profile.nat_instance_profile.name}"
+  monitoring           = true
+
+  lifecycle {
+    ignore_changes = [
+      "*",
+    ]
+  }
+}

--- a/modules/aws/vpc/variable.tf
+++ b/modules/aws/vpc/variable.tf
@@ -23,3 +23,22 @@ variable "vpc" {
     stg.private_1d     = "10.3.12.0/24"
   }
 }
+
+variable "nat_instance" {
+  type = "map"
+
+  default = {
+    default.name          = "prod-nat"
+    stg.name              = "stg-nat"
+    default.ami           = "ami-00d29e4cb217ae06b"
+    default.instance_type = "t2.micro"
+    default.volume_type   = "gp2"
+    default.volume_size   = "30"
+  }
+}
+
+variable "ssh_public_key_path" {
+  type = "string"
+
+  default = ""
+}

--- a/providers/aws/environments/10-network/main.tf
+++ b/providers/aws/environments/10-network/main.tf
@@ -1,3 +1,4 @@
 module "vpc" {
-  source = "../../../../modules/aws/vpc"
+  source              = "../../../../modules/aws/vpc"
+  ssh_public_key_path = "${var.ssh_public_key_path}"
 }

--- a/providers/aws/environments/10-network/variable.tf
+++ b/providers/aws/environments/10-network/variable.tf
@@ -1,0 +1,5 @@
+variable "ssh_public_key_path" {
+  type = "string"
+
+  default = ""
+}

--- a/scripts/createProvider.ts
+++ b/scripts/createProvider.ts
@@ -13,7 +13,7 @@ const createProvider = async (
     outputPath,
     awsProviderParams: [
       {
-        version: "=2.2.0",
+        version: "=2.4.0",
         region,
         profile: awsProfileName(deployStage)
       }

--- a/scripts/createTerraformConfig.ts
+++ b/scripts/createTerraformConfig.ts
@@ -17,7 +17,7 @@ import {
   createFrontendTfvars,
   createRdsTfvars,
   createEcsTfvars,
-  createFargateTfvars
+  createFargateTfvars, createNetworkTfvars
 } from "./createTfvars";
 import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
 
@@ -44,6 +44,7 @@ import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
     await createProvider(deployStage, dir);
   });
 
+  await createNetworkTfvars(deployStage);
   await createAcmTfvars(deployStage);
   await createBastionTfvars(deployStage);
   await createApiTfvars(deployStage);

--- a/scripts/createTerraformConfig.ts
+++ b/scripts/createTerraformConfig.ts
@@ -17,7 +17,8 @@ import {
   createFrontendTfvars,
   createRdsTfvars,
   createEcsTfvars,
-  createFargateTfvars, createNetworkTfvars
+  createFargateTfvars,
+  createNetworkTfvars
 } from "./createTfvars";
 import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
 
@@ -29,29 +30,30 @@ import { isAllowedDeployStage, outputPathList } from "./terraformConfigUtil";
     );
   }
 
-  await createNetworkBackend(deployStage);
-  await createAcmBackend(deployStage);
-  await createBastionBackend(deployStage);
-  await createApiBackend(deployStage);
-  await createFrontendBackend(deployStage);
-  await createRdsBackend(deployStage);
-  await createEcrBackend(deployStage);
-  await createEcsBackend(deployStage);
-  await createFargateBackend(deployStage);
+  await Promise.all([
+    createNetworkBackend(deployStage),
+    createAcmBackend(deployStage),
+    createBastionBackend(deployStage),
+    createApiBackend(deployStage),
+    createFrontendBackend(deployStage),
+    createRdsBackend(deployStage),
+    createEcrBackend(deployStage),
+    createEcsBackend(deployStage),
+    createFargateBackend(deployStage),
+    createNetworkTfvars(deployStage),
+    createAcmTfvars(deployStage),
+    createBastionTfvars(deployStage),
+    createApiTfvars(deployStage),
+    createFrontendTfvars(deployStage),
+    createRdsTfvars(deployStage),
+    createEcsTfvars(deployStage),
+    createFargateTfvars(deployStage)
+  ]);
 
-  const targetDirs = outputPathList();
-  targetDirs.forEach(async (dir: string) => {
-    await createProvider(deployStage, dir);
+  const promises = outputPathList().map((dir: string) => {
+    return createProvider(deployStage, dir);
   });
-
-  await createNetworkTfvars(deployStage);
-  await createAcmTfvars(deployStage);
-  await createBastionTfvars(deployStage);
-  await createApiTfvars(deployStage);
-  await createFrontendTfvars(deployStage);
-  await createRdsTfvars(deployStage);
-  await createEcsTfvars(deployStage);
-  await createFargateTfvars(deployStage);
+  await Promise.all(promises);
 
   return Promise.resolve();
 })().catch((error: Error) => {

--- a/scripts/createTfvars.ts
+++ b/scripts/createTfvars.ts
@@ -9,6 +9,22 @@ const secretIds = (deployStage: string) => {
   return [`${deployStage}/qiita-stocker-terraform`];
 };
 
+export const createNetworkTfvars = async (deployStage: string): Promise<void> => {
+  const params = {
+    region: AwsRegion.ap_northeast_1,
+    profile: awsProfileName(deployStage),
+    type: EnvFileType.terraform,
+    outputDir: "./providers/aws/environments/10-network/",
+    secretIds: secretIds(deployStage),
+    outputWhitelist: ["SSH_PUBLIC_KEY_PATH"],
+    keyMapping: {
+      SSH_PUBLIC_KEY_PATH: "ssh_public_key_path"
+    }
+  };
+
+  await createEnvFile(params);
+};
+
 export const createAcmTfvars = async (deployStage: string): Promise<void> => {
   const params = {
     region: AwsRegion.ap_northeast_1,
@@ -130,4 +146,3 @@ export const createFargateTfvars = async (
 
   await createEnvFile(params);
 };
-createFargateTfvars;

--- a/scripts/createTfvars.ts
+++ b/scripts/createTfvars.ts
@@ -9,7 +9,9 @@ const secretIds = (deployStage: string) => {
   return [`${deployStage}/qiita-stocker-terraform`];
 };
 
-export const createNetworkTfvars = async (deployStage: string): Promise<void> => {
+export const createNetworkTfvars = async (
+  deployStage: string
+): Promise<void> => {
   const params = {
     region: AwsRegion.ap_northeast_1,
     profile: awsProfileName(deployStage),

--- a/scripts/terraformConfigUtil.ts
+++ b/scripts/terraformConfigUtil.ts
@@ -1,5 +1,5 @@
 export const terraformVersion = (): string => {
-  return "=0.11.10";
+  return "=0.11.13";
 };
 
 export const tfstateBucketName = (deployStage: string): string => {

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,7 @@
     "prettier": true,
 
     // TSLint Standard
-    "max-file-line-count": [true, 200],
+    "max-file-line-count": [true, 270],
     "variable-name": false,
     "strict-boolean-expressions": false,
     "no-parameter-properties": true,


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/60

# Doneの定義
- NATインスタンスが作成されprivateサブネットがNATインスタンス経由でインターネット接続を行うようになっている事

# 変更点概要

## 技術的変更点概要
- NATInstanceを作成しprivate route tableのインターネット接続をNATInstance経由に変更

http, https共にアクセスできる事を確認

```
$ curl -D - -s  -o /dev/null https://www.mindexer.net
HTTP/2 200
content-type: text/html
content-length: 1787
date: Thu, 04 Apr 2019 01:38:37 GMT
last-modified: Fri, 29 Mar 2019 13:29:51 GMT
etag: "f72390f01faf51623dc0dce1b0252d99"
accept-ranges: bytes
server: AmazonS3
age: 666
x-cache: Hit from cloudfront
via: 1.1 e4404fd3b1d2ac38d3124fbc6bbedc8b.cloudfront.net (CloudFront)
x-amz-cf-id: gFEr5mSLCmBYrRzcYwXpsnZIurd41BSyJLgZxmLLuFCnyNz-ahJfKw==


$ curl -D - -s  -o /dev/null http://www.metro.tokyo.jp
HTTP/1.0 200 OK
Date: Thu, 04 Apr 2019 01:49:59 GMT
Last-Modified: Thu, 04 Apr 2019 00:06:43 GMT
ETag: "fe44e1-487e-585a925298ac0"
Accept-Ranges: bytes
Content-Length: 18558
Content-Type: text/html
X-Pad: avoid browser bug
Via: 1.1 ID-0002262070470144 uproxy-2
X-Frame-Options: SAMEORIGIN
```

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 NAT Instanceの作成と共に以下の対応を行ってるよ🐱！

- Terraform, terraform-provider-aws を最新の安定版に更新
- `createTerraformConfig.ts` のリファクタリング（Promise.allを使った処理の並列化）

NAT用のinstanceなんだけど、module/vpcの中に作成する事にした、理由としては `aws_route_table.private` に作成したNATInstanceのIDを指定しないとイケないから、SSHのキーペアを専用でもう一組作ったり（中身は同じだけど）SSH接続をVPCのcidr_blocksから全て許可していたり結構トリッキーな事をやっちゃってる・・・

本当はbastionサーバー、NATInstance、VPCは同じmodule内にあったほうが楽なんだけど、以下の理由で今回のやり方を採用してるよ！

- Instanceの再構築が必要な為（APIサーバーのInstanceもbastionサーバーに依存している）
- もうすぐFargateに置き換わるので、サーバーにSSHする行為そのものが不要になる可能性が高い（SSH接続しなければいけないサーバーは今回作ったNATInstanceと検証用に立ち上げるECS用のEC2くらい）

もしNATインスタンスに障害が起こった場合は今回作った `1c` とは別のAZに新しいNATインスタンスを作成してルーティングを新しく作成したNATインスタンスに修正する予定だよ！

# 補足情報
NATGatewayの削除はこのPRでは行っていないので、このPRが承認されmergeされ次第、別途PRを作成し対応する。（NATGatewayの削除後は月額ランニングコストがかなり安くなる見込み）


```
Host stg-qiita-stocker-nat-1c
    HostName ${NATインスタンスのローカルIP}
    Port 22
    User ec2-user
    IdentityFile ~/.ssh/stg_qiita_stocker_aws.pem
    ProxyCommand ssh -W %h:%p stg-qiita-stocker-bastion-1a
```