### PR TITLE
qiita-stocker-frontend専用のパラメータストアを生成する

### DIFF
--- a/modules/aws/frontend/local_ssm_parameter.tf
+++ b/modules/aws/frontend/local_ssm_parameter.tf
@@ -1,0 +1,55 @@
+resource "aws_ssm_parameter" "local_frontend_app_url" {
+  count     = "${terraform.workspace == "stg" ? 1 : 0}"
+  name      = "/local/qiita-stocker/frontend/VUE_APP_API_URL_BASE"
+  type      = "SecureString"
+  value     = "${data.external.local_frontend.result["BACKEND_URL"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "local_frontend_qiita_client_id" {
+  count     = "${terraform.workspace == "stg" ? 1 : 0}"
+  name      = "/local/qiita-stocker/frontend/VUE_APP_QIITA_CLIENT_ID"
+  type      = "SecureString"
+  value     = "${data.external.local_frontend.result["QIITA_CLIENT_ID"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "local_frontend_qiita_client_secret" {
+  count     = "${terraform.workspace == "stg" ? 1 : 0}"
+  name      = "/local/qiita-stocker/frontend/VUE_APP_QIITA_CLIENT_SECRET"
+  type      = "SecureString"
+  value     = "${data.external.local_frontend.result["QIITA_CLIENT_SECRET"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "local_frontend_qiita_redirect_uri" {
+  count     = "${terraform.workspace == "stg" ? 1 : 0}"
+  name      = "/local/qiita-stocker/frontend/VUE_APP_QIITA_REDIRECT_URI"
+  type      = "SecureString"
+  value     = "${data.external.local_frontend.result["QIITA_REDIRECT_URI"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "local_frontend_tracking_id" {
+  count     = "${terraform.workspace == "stg" ? 1 : 0}"
+  name      = "/local/qiita-stocker/frontend/VUE_APP_TRACKING_ID"
+  type      = "SecureString"
+  value     = "${data.external.local_frontend.result["TRACKING_ID"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "local_frontend_google_site_verification" {
+  count     = "${terraform.workspace == "stg" ? 1 : 0}"
+  name      = "/local/qiita-stocker/frontend/VUE_APP_GOOGLE_SITE_VERIFICATION"
+  type      = "SecureString"
+  value     = "${data.external.local_frontend.result["GOOGLE_SITE_VERIFICATION"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "local_frontend_app_stage" {
+  count     = "${terraform.workspace == "stg" ? 1 : 0}"
+  name      = "/local/qiita-stocker/frontend/VUE_APP_STAGE"
+  type      = "String"
+  value     = "local"
+  overwrite = true
+}

--- a/modules/aws/frontend/secretsmanager.tf
+++ b/modules/aws/frontend/secretsmanager.tf
@@ -1,0 +1,26 @@
+data "aws_secretsmanager_secret" "frontend" {
+  name = "${terraform.workspace}/qiita-stocker"
+}
+
+data "aws_secretsmanager_secret_version" "frontend" {
+  secret_id = "${data.aws_secretsmanager_secret.frontend.id}"
+}
+
+data "external" "frontend" {
+  program = ["echo", "${data.aws_secretsmanager_secret_version.frontend.secret_string}"]
+}
+
+data "aws_secretsmanager_secret" "local_frontend" {
+  count = "${terraform.workspace == "stg" ? 1 : 0}"
+  name  = "local/qiita-stocker"
+}
+
+data "aws_secretsmanager_secret_version" "local_frontend" {
+  count     = "${terraform.workspace == "stg" ? 1 : 0}"
+  secret_id = "${data.aws_secretsmanager_secret.local_frontend.id}"
+}
+
+data "external" "local_frontend" {
+  count   = "${terraform.workspace == "stg" ? 1 : 0}"
+  program = ["echo", "${data.aws_secretsmanager_secret_version.local_frontend.secret_string}"]
+}

--- a/modules/aws/frontend/ssm_parameter.tf
+++ b/modules/aws/frontend/ssm_parameter.tf
@@ -1,0 +1,48 @@
+resource "aws_ssm_parameter" "frontend_app_url" {
+  name      = "/${terraform.workspace}/qiita-stocker/frontend/VUE_APP_API_URL_BASE"
+  type      = "SecureString"
+  value     = "${data.external.frontend.result["BACKEND_URL"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "frontend_qiita_client_id" {
+  name      = "/${terraform.workspace}/qiita-stocker/frontend/VUE_APP_QIITA_CLIENT_ID"
+  type      = "SecureString"
+  value     = "${data.external.frontend.result["QIITA_CLIENT_ID"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "frontend_qiita_client_secret" {
+  name      = "/${terraform.workspace}/qiita-stocker/frontend/VUE_APP_QIITA_CLIENT_SECRET"
+  type      = "SecureString"
+  value     = "${data.external.frontend.result["QIITA_CLIENT_SECRET"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "frontend_qiita_redirect_uri" {
+  name      = "/${terraform.workspace}/qiita-stocker/frontend/VUE_APP_QIITA_REDIRECT_URI"
+  type      = "SecureString"
+  value     = "${data.external.frontend.result["QIITA_REDIRECT_URI"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "frontend_tracking_id" {
+  name      = "/${terraform.workspace}/qiita-stocker/frontend/VUE_APP_TRACKING_ID"
+  type      = "SecureString"
+  value     = "${data.external.frontend.result["TRACKING_ID"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "frontend_google_site_verification" {
+  name      = "/${terraform.workspace}/qiita-stocker/frontend/VUE_APP_GOOGLE_SITE_VERIFICATION"
+  type      = "SecureString"
+  value     = "${data.external.frontend.result["GOOGLE_SITE_VERIFICATION"]}"
+  overwrite = true
+}
+
+resource "aws_ssm_parameter" "frontend_app_stage" {
+  name      = "/${terraform.workspace}/qiita-stocker/frontend/VUE_APP_STAGE"
+  type      = "String"
+  value     = "${terraform.workspace}"
+  overwrite = true
+}


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/79

# Doneの定義
SeecretManagerからFrontendに利用する環境変数が全て定義されているParameterStoreが作成されている事

# 変更点概要

## 技術的変更点概要
qiita-stocker-frontend専用のパラメータストアを生成。

# 補足
現時点では必要ではないけれど、Nuxt.jsへの移行で必要となるため作成。