### PR TITLE
CodeBuildからParameterStoreに接続出来るように設定を変更

### DIFF
--- a/modules/aws/api/codebuild.tf
+++ b/modules/aws/api/codebuild.tf
@@ -22,8 +22,6 @@ resource "aws_iam_role" "codebuild_role" {
   assume_role_policy = "${data.aws_iam_policy_document.codebuild_trust_relationship.json}"
 }
 
-// TODO 本当は良くないけど適切な権限設定が分からなかったのでAdministratorAccessを付与しておく
-// TODO 適切な権限設定が分かった時点で権限を見直す
 resource "aws_iam_role_policy_attachment" "attach_admin_access_to_codebuild_role" {
   role       = "${aws_iam_role.codebuild_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/AdministratorAccess"
@@ -59,6 +57,108 @@ resource "aws_codebuild_project" "api_rds_migration" {
     environment_variable {
       name  = "DEPLOY_STAGE"
       value = "${terraform.workspace}"
+    }
+
+    environment_variable {
+      name  = "CORS_ORIGIN"
+      value = "${aws_ssm_parameter.api_cors_origin.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "APP_URL"
+      value = "${aws_ssm_parameter.api_app_url.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "APP_KEY"
+      value = "${aws_ssm_parameter.api_app_key.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_PASSWORD"
+      value = "${aws_ssm_parameter.api_db_password.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "NOTIFICATION_SLACK_TOKEN"
+      value = "${aws_ssm_parameter.api_slack_token.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "NOTIFICATION_SLACK_CHANNEL"
+      value = "${aws_ssm_parameter.api_slack_channel.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "APP_NAME"
+      value = "${aws_ssm_parameter.api_app_name.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "APP_ENV"
+      value = "${aws_ssm_parameter.api_app_env.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "APP_DEBUG"
+      value = "${aws_ssm_parameter.api_app_debug.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "LOG_CHANNEL"
+      value = "${aws_ssm_parameter.api_log_channel.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_CONNECTION"
+      value = "${aws_ssm_parameter.api_db_connection.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_HOST"
+      value = "${aws_ssm_parameter.api_db_host.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_PORT"
+      value = "${aws_ssm_parameter.api_db_port.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_DATABASE"
+      value = "${aws_ssm_parameter.api_db_database.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "DB_USERNAME"
+      value = "${aws_ssm_parameter.api_db_username.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "BROADCAST_DRIVER"
+      value = "${aws_ssm_parameter.api_broadcast_driver.name}"
+      type  = "PARAMETER_STORE"
+    }
+
+    environment_variable {
+      name  = "MAINTENANCE_MODE"
+      value = "${aws_ssm_parameter.api_maintenance_mode.name}"
+      type  = "PARAMETER_STORE"
     }
   }
 

--- a/modules/aws/api/fargate.tf
+++ b/modules/aws/api/fargate.tf
@@ -86,6 +86,7 @@ resource "aws_ecs_service" "api_fargate_service" {
     ignore_changes = [
       "task_definition",
       "load_balancer",
+      "desired_count",
     ]
   }
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/83

# Doneの定義
- `${環境名}-api-rds-migration` が正常に実行出来るようになっている事

# 変更点概要

## 仕様的変更点概要
CodeBuildプロジェクトにParameterStoreを設定しコンテナ内から参照出来るように変更

## 技術的変更点概要
`aws_codebuild_project.api_rds_migration.environment_variable` にParameterStoreの項目を設定。

Build実行時にParameterStoreから参照する形なのでPassword等の機密情報がCodeBuild上から閲覧出来ないので、セキュアになっている。

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 最初は `aws_iam_policy_document` に権限を追加しようと思ったけど、ParameterStoreを `environment_variable` に設定するほうがより安全になると思ったからこの方法にしたよ🐱！

こうなると `buildspec-migration.yml` に書かれている `yarn install` とか `yarn run createDotenv:${DEPLOY_STAGE}` の実行、今CodeBuild内で定義されている `DEPLOY_STAGE` の変数も不要になるから、これに関しては https://github.com/nekochans/qiita-stocker-backend/issues/190 と https://github.com/nekochans/qiita-stocker-terraform/issues/89 で削除対応する予定だよ！

※今は `DEPLOY_STAGE` が定義されていないと `yarn run createDotenv:${DEPLOY_STAGE}` が失敗してbuildが失敗扱いになってしまうから残してある