### PR TITLE
Fargateの環境変数にqiita-stocker-backendのParameterStoreを設定

### DIFF
--- a/modules/aws/api/ecs.tf
+++ b/modules/aws/api/ecs.tf
@@ -85,8 +85,25 @@ data "template_file" "api_template_file" {
   template = "${file("../../../../modules/aws/api/task/ecs-api.json")}"
 
   vars {
-    php_image_url   = "${element(var.ecr["php_image_url"], 0)}"
-    nginx_image_url = "${element(var.ecr["nginx_image_url"], 0)}"
+    php_image_url            = "${element(var.ecr["php_image_url"], 0)}"
+    nginx_image_url          = "${element(var.ecr["nginx_image_url"], 0)}"
+    api_cors_origin_arn      = "${aws_ssm_parameter.api_cors_origin.arn}"
+    api_app_url_arn          = "${aws_ssm_parameter.api_app_url.arn}"
+    api_app_key_arn          = "${aws_ssm_parameter.api_app_key.arn}"
+    api_db_password_arn      = "${aws_ssm_parameter.api_db_password.arn}"
+    api_slack_token_arn      = "${aws_ssm_parameter.api_slack_token.arn}"
+    api_slack_channel_arn    = "${aws_ssm_parameter.api_slack_channel.arn}"
+    api_app_name_arn         = "${aws_ssm_parameter.api_app_name.arn}"
+    api_app_env_arn          = "${aws_ssm_parameter.api_app_env.arn}"
+    api_app_debug_arn        = "${aws_ssm_parameter.api_app_debug.arn}"
+    api_log_channel_arn      = "${aws_ssm_parameter.api_log_channel.arn}"
+    api_db_connection_arn    = "${aws_ssm_parameter.api_db_connection.arn}"
+    api_db_host_arn          = "${aws_ssm_parameter.api_db_host.arn}"
+    api_db_port_arn          = "${aws_ssm_parameter.api_db_port.arn}"
+    api_db_database_arn      = "${aws_ssm_parameter.api_db_database.arn}"
+    api_db_username_arn      = "${aws_ssm_parameter.api_db_username.arn}"
+    api_broadcast_driver_arn = "${aws_ssm_parameter.api_broadcast_driver.arn}"
+    api_maintenance_mode_arn = "${aws_ssm_parameter.api_maintenance_mode.arn}"
   }
 }
 
@@ -95,6 +112,7 @@ resource "aws_ecs_task_definition" "api" {
   family                = "${lookup(var.ecs, "${terraform.env}.name", var.ecs["default.name"])}"
   network_mode          = "bridge"
   container_definitions = "${data.template_file.api_template_file.rendered}"
+  execution_role_arn    = "${aws_iam_role.task_execution_role.arn}"
 }
 
 resource "aws_ecs_service" "api_ecs_service" {

--- a/modules/aws/api/fargate.tf
+++ b/modules/aws/api/fargate.tf
@@ -37,10 +37,27 @@ data "template_file" "api_fargate_template_file" {
   template = "${file("../../../../modules/aws/api/task/fargate-api.json")}"
 
   vars {
-    aws_region      = "${lookup(var.fargate, "region")}"
-    php_image_url   = "${element(var.ecr["php_image_url"], 0)}"
-    nginx_image_url = "${element(var.ecr["nginx_image_url"], 0)}"
-    aws_logs_group  = "${aws_cloudwatch_log_group.fargate_api.name}"
+    aws_region               = "${lookup(var.fargate, "region")}"
+    php_image_url            = "${element(var.ecr["php_image_url"], 0)}"
+    nginx_image_url          = "${element(var.ecr["nginx_image_url"], 0)}"
+    aws_logs_group           = "${aws_cloudwatch_log_group.fargate_api.name}"
+    api_cors_origin_arn      = "${aws_ssm_parameter.api_cors_origin.arn}"
+    api_app_url_arn          = "${aws_ssm_parameter.api_app_url.arn}"
+    api_app_key_arn          = "${aws_ssm_parameter.api_app_key.arn}"
+    api_db_password_arn      = "${aws_ssm_parameter.api_db_password.arn}"
+    api_slack_token_arn      = "${aws_ssm_parameter.api_slack_token.arn}"
+    api_slack_channel_arn    = "${aws_ssm_parameter.api_slack_channel.arn}"
+    api_app_name_arn         = "${aws_ssm_parameter.api_app_name.arn}"
+    api_app_env_arn          = "${aws_ssm_parameter.api_app_env.arn}"
+    api_app_debug_arn        = "${aws_ssm_parameter.api_app_debug.arn}"
+    api_log_channel_arn      = "${aws_ssm_parameter.api_log_channel.arn}"
+    api_db_connection_arn    = "${aws_ssm_parameter.api_db_connection.arn}"
+    api_db_host_arn          = "${aws_ssm_parameter.api_db_host.arn}"
+    api_db_port_arn          = "${aws_ssm_parameter.api_db_port.arn}"
+    api_db_database_arn      = "${aws_ssm_parameter.api_db_database.arn}"
+    api_db_username_arn      = "${aws_ssm_parameter.api_db_username.arn}"
+    api_broadcast_driver_arn = "${aws_ssm_parameter.api_broadcast_driver.arn}"
+    api_maintenance_mode_arn = "${aws_ssm_parameter.api_maintenance_mode.arn}"
   }
 }
 

--- a/modules/aws/api/iam.tf
+++ b/modules/aws/api/iam.tf
@@ -47,16 +47,10 @@ resource "aws_iam_role" "ecs_service_role" {
   assume_role_policy = "${data.aws_iam_policy_document.ecs_service_trust_relationship.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_service_role_attach_to_ecs_role" {
+resource "aws_iam_role_policy_attachment" "ecs_service_role_attach" {
   count      = "${terraform.workspace != "prod" ? 1 : 0}"
   role       = "${aws_iam_role.ecs_service_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
-}
-
-resource "aws_iam_role_policy_attachment" "ssm_read_only_access_role_attach_to_ecs_role" {
-  count      = "${terraform.workspace != "prod" ? 1 : 0}"
-  role       = "${aws_iam_role.ecs_service_role.name}"
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
 }
 
 data "aws_iam_policy_document" "task_execution_trust_relationship" {
@@ -77,12 +71,12 @@ resource "aws_iam_role" "task_execution_role" {
   assume_role_policy = "${data.aws_iam_policy_document.task_execution_trust_relationship.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "task_execution_role_attach_to_task_execution_role" {
+resource "aws_iam_role_policy_attachment" "task_execution_role_attach" {
   role       = "${aws_iam_role.task_execution_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-resource "aws_iam_role_policy_attachment" "ssm_read_only_access_role_attach_to_task_execution_role" {
+resource "aws_iam_role_policy_attachment" "ssm_read_only_access_role_attach" {
   role       = "${aws_iam_role.task_execution_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
 }

--- a/modules/aws/api/iam.tf
+++ b/modules/aws/api/iam.tf
@@ -76,3 +76,9 @@ resource "aws_iam_policy_attachment" "task_execution_role_attach" {
   roles      = ["${aws_iam_role.task_execution_role.name}"]
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
+
+resource "aws_iam_policy_attachment" "task_execution_role_attach_ssm_role" {
+  name       = "ecs-task-role-attach-ssm-role"
+  roles      = ["${aws_iam_role.task_execution_role.name}"]
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}

--- a/modules/aws/api/iam.tf
+++ b/modules/aws/api/iam.tf
@@ -53,6 +53,13 @@ resource "aws_iam_role_policy_attachment" "ecs_service_role_attach" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
+resource "aws_iam_policy_attachment" "ecs_service_role_attach_ssm_role" {
+  count      = "${terraform.workspace != "prod" ? 1 : 0}"
+  name       = "ecs-service-role-attach-ssm-role"
+  roles      = ["${aws_iam_role.ecs_service_role.name}"]
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}
+
 data "aws_iam_policy_document" "task_execution_trust_relationship" {
   "statement" {
     effect = "Allow"

--- a/modules/aws/api/iam.tf
+++ b/modules/aws/api/iam.tf
@@ -47,16 +47,15 @@ resource "aws_iam_role" "ecs_service_role" {
   assume_role_policy = "${data.aws_iam_policy_document.ecs_service_trust_relationship.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "ecs_service_role_attach" {
+resource "aws_iam_role_policy_attachment" "ecs_service_role_attach_to_ecs_role" {
   count      = "${terraform.workspace != "prod" ? 1 : 0}"
   role       = "${aws_iam_role.ecs_service_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole"
 }
 
-resource "aws_iam_policy_attachment" "ecs_service_role_attach_ssm_role" {
+resource "aws_iam_role_policy_attachment" "ssm_read_only_access_role_attach_to_ecs_role" {
   count      = "${terraform.workspace != "prod" ? 1 : 0}"
-  name       = "ecs-service-role-attach-ssm-role"
-  roles      = ["${aws_iam_role.ecs_service_role.name}"]
+  role       = "${aws_iam_role.ecs_service_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
 }
 
@@ -78,14 +77,12 @@ resource "aws_iam_role" "task_execution_role" {
   assume_role_policy = "${data.aws_iam_policy_document.task_execution_trust_relationship.json}"
 }
 
-resource "aws_iam_policy_attachment" "task_execution_role_attach" {
-  name       = "ecs-task-role-attach"
-  roles      = ["${aws_iam_role.task_execution_role.name}"]
+resource "aws_iam_role_policy_attachment" "task_execution_role_attach_to_task_execution_role" {
+  role       = "${aws_iam_role.task_execution_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
 }
 
-resource "aws_iam_policy_attachment" "task_execution_role_attach_ssm_role" {
-  name       = "ecs-task-role-attach-ssm-role"
-  roles      = ["${aws_iam_role.task_execution_role.name}"]
+resource "aws_iam_role_policy_attachment" "ssm_read_only_access_role_attach_to_task_execution_role" {
+  role       = "${aws_iam_role.task_execution_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
 }

--- a/modules/aws/api/task/ecs-api.json
+++ b/modules/aws/api/task/ecs-api.json
@@ -3,7 +3,77 @@
     "name": "php",
     "image": "${php_image_url}",
     "memory": 300,
-    "essential": true
+    "essential": true,
+    "secrets": [
+      {
+        "name": "CORS_ORIGIN",
+        "valueFrom": "${api_cors_origin_arn}"
+      },
+      {
+        "name": "APP_URL",
+        "valueFrom": "${api_app_url_arn}"
+      },
+      {
+        "name": "APP_KEY",
+        "valueFrom": "${api_app_key_arn}"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "valueFrom": "${api_db_password_arn}"
+      },
+      {
+        "name": "NOTIFICATION_SLACK_TOKEN",
+        "valueFrom": "${api_slack_token_arn}"
+      },
+      {
+        "name": "NOTIFICATION_SLACK_CHANNEL",
+        "valueFrom": "${api_slack_channel_arn}"
+      },
+      {
+        "name": "APP_NAME",
+        "valueFrom": "${api_app_name_arn}"
+      },
+      {
+        "name": "APP_ENV",
+        "valueFrom": "${api_app_env_arn}"
+      },
+      {
+        "name": "APP_DEBUG",
+        "valueFrom": "${api_app_debug_arn}"
+      },
+      {
+        "name": "LOG_CHANNEL",
+        "valueFrom": "${api_log_channel_arn}"
+      },
+      {
+        "name": "DB_CONNECTION",
+        "valueFrom": "${api_db_connection_arn}"
+      },
+      {
+        "name": "DB_HOST",
+        "valueFrom": "${api_db_host_arn}"
+      },
+      {
+        "name": "DB_PORT",
+        "valueFrom": "${api_db_port_arn}"
+      },
+      {
+        "name": "DB_DATABASE",
+        "valueFrom": "${api_db_database_arn}"
+      },
+      {
+        "name": "DB_USERNAME",
+        "valueFrom": "${api_db_username_arn}"
+      },
+      {
+        "name": "BROADCAST_DRIVER",
+        "valueFrom": "${api_broadcast_driver_arn}"
+      },
+      {
+        "name": "MAINTENANCE_MODE",
+        "valueFrom": "${api_maintenance_mode_arn}"
+      }
+    ]
   },
   {
     "name": "nginx",

--- a/modules/aws/api/task/fargate-api.json
+++ b/modules/aws/api/task/fargate-api.json
@@ -11,7 +11,77 @@
         "awslogs-region": "${aws_region}",
         "awslogs-stream-prefix": "ecs"
       }
-    }
+    },
+    "secrets": [
+      {
+        "name": "CORS_ORIGIN",
+        "valueFrom": "${api_cors_origin_arn}"
+      },
+      {
+        "name": "APP_URL",
+        "valueFrom": "${api_app_url_arn}"
+      },
+      {
+        "name": "APP_KEY",
+        "valueFrom": "${api_app_key_arn}"
+      },
+      {
+        "name": "DB_PASSWORD",
+        "valueFrom": "${api_db_password_arn}"
+      },
+      {
+        "name": "NOTIFICATION_SLACK_TOKEN",
+        "valueFrom": "${api_slack_token_arn}"
+      },
+      {
+        "name": "NOTIFICATION_SLACK_CHANNEL",
+        "valueFrom": "${api_slack_channel_arn}"
+      },
+      {
+        "name": "APP_NAME",
+        "valueFrom": "${api_app_name_arn}"
+      },
+      {
+        "name": "APP_ENV",
+        "valueFrom": "${api_app_env_arn}"
+      },
+      {
+        "name": "APP_DEBUG",
+        "valueFrom": "${api_app_debug_arn}"
+      },
+      {
+        "name": "LOG_CHANNEL",
+        "valueFrom": "${api_log_channel_arn}"
+      },
+      {
+        "name": "DB_CONNECTION",
+        "valueFrom": "${api_db_connection_arn}"
+      },
+      {
+        "name": "DB_HOST",
+        "valueFrom": "${api_db_host_arn}"
+      },
+      {
+        "name": "DB_PORT",
+        "valueFrom": "${api_db_port_arn}"
+      },
+      {
+        "name": "DB_DATABASE",
+        "valueFrom": "${api_db_database_arn}"
+      },
+      {
+        "name": "DB_USERNAME",
+        "valueFrom": "${api_db_username_arn}"
+      },
+      {
+        "name": "BROADCAST_DRIVER",
+        "valueFrom": "${api_broadcast_driver_arn}"
+      },
+      {
+        "name": "MAINTENANCE_MODE",
+        "valueFrom": "${api_maintenance_mode_arn}"
+      }
+    ]
   },
   {
     "name": "nginx",


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/74

# Doneの定義
- Fargateのタスク実行時にParameterStoreから環境変数を取得出来るようになっている事

# 変更点概要

## 技術的変更点概要
- ECSの実行ロールにParameterStoreへの参照権限を追加
- ECSの環境変数にParameterStoreの変数を追加

# レビュアーに重点的にチェックして欲しい点
@kobayashi-m42 `aws_iam_policy_attachment` を使っていると常にTerraformの差分が出るようになってしまったから `aws_iam_role_policy_attachment` のみを使うように修正したよ🐱

https://qiita.com/billthelizard/items/8b54c40351e2ff39afa0

この記事によると `aws_iam_policy_attachment ` は非推奨みたい！（名前がややこしい・・・）