### PR TITLE
Migration用のCodeBuildプロジェクトからDEPLOY_STAGEを削除

### DIFF
--- a/modules/aws/api/codebuild.tf
+++ b/modules/aws/api/codebuild.tf
@@ -55,11 +55,6 @@ resource "aws_codebuild_project" "api_rds_migration" {
     type         = "LINUX_CONTAINER"
 
     environment_variable {
-      name  = "DEPLOY_STAGE"
-      value = "${terraform.workspace}"
-    }
-
-    environment_variable {
       name  = "CORS_ORIGIN"
       value = "${aws_ssm_parameter.api_cors_origin.name}"
       type  = "PARAMETER_STORE"


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/89

# Doneの定義
- 不要になった変数 `DEPLOY_STAGE ` が削除されている事

# 変更点概要

## 技術的変更点概要
- `aws_codebuild_project.api_rds_migration` から `DEPLOY_STAGE ` を削除、その後、Migration用のBuildが正常終了する事を確認