### PR TITLE
DatadogでFargateを監視する環境を構築する

### DIFF
--- a/modules/aws/api/fargate.tf
+++ b/modules/aws/api/fargate.tf
@@ -58,6 +58,7 @@ data "template_file" "api_fargate_template_file" {
     api_db_username_arn      = "${aws_ssm_parameter.api_db_username.arn}"
     api_broadcast_driver_arn = "${aws_ssm_parameter.api_broadcast_driver.arn}"
     api_maintenance_mode_arn = "${aws_ssm_parameter.api_maintenance_mode.arn}"
+    api_datadog_api_key_arn  = "${aws_ssm_parameter.api_datadog_api_key.arn}"
   }
 }
 

--- a/modules/aws/api/iam.tf
+++ b/modules/aws/api/iam.tf
@@ -80,3 +80,23 @@ resource "aws_iam_role_policy_attachment" "ssm_read_only_access_role_attach" {
   role       = "${aws_iam_role.task_execution_role.name}"
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
 }
+
+data "aws_iam_policy_document" "datadog_agent_container_policy" {
+  "statement" {
+    effect = "Allow"
+
+    actions = [
+      "ecs:ListClusters",
+      "ecs:ListContainerInstances",
+      "ecs:DescribeContainerInstances",
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecs_instance" {
+  name   = "${terraform.workspace}-datadog-agent-container-policy"
+  role   = "${aws_iam_role.task_execution_role.id}"
+  policy = "${data.aws_iam_policy_document.datadog_agent_container_policy.json}"
+}

--- a/modules/aws/api/ssm_parameter.tf
+++ b/modules/aws/api/ssm_parameter.tf
@@ -40,6 +40,13 @@ resource "aws_ssm_parameter" "api_slack_channel" {
   overwrite = true
 }
 
+resource "aws_ssm_parameter" "api_datadog_api_key" {
+  name      = "/${terraform.workspace}/qiita-stocker/api/DD_API_KEY"
+  type      = "SecureString"
+  value     = "${data.external.api.result["DATADOG_API_KEY"]}"
+  overwrite = true
+}
+
 resource "aws_ssm_parameter" "api_app_name" {
   name      = "/${terraform.workspace}/qiita-stocker/api/APP_NAME"
   type      = "String"

--- a/modules/aws/api/task/fargate-api.json
+++ b/modules/aws/api/task/fargate-api.json
@@ -103,5 +103,24 @@
         "awslogs-stream-prefix": "ecs"
       }
     }
+  },
+  {
+    "name": "datadog-agent",
+    "image": "datadog/agent:latest",
+    "memoryReservation": 256,
+    "essential": true,
+    "cpu": 10,
+    "secrets": [
+      {
+        "name": "DD_API_KEY",
+        "valueFrom": "${api_datadog_api_key_arn}"
+      }
+    ],
+    "environment": [
+      {
+        "name": "ECS_FARGATE",
+        "value": "true"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/98

# Doneの定義
- STG環境にDatadogでFargateを監視する環境が構築されていること

# 変更点概要

## 仕様的変更点概要
DatadogでFargateのコンテナを監視できるように、Datadogのコンテナを追加。

## 技術的変更点概要
DatadogでFargateのコンテナを監視できるように下記の変更を行なった。
- Fargateのタスクの定義にDatadogのコンテナを追加
- タスクの実行ロールに、Datadog用のIAMポリシーをアタッチ
- マネジメントコンソールより、DatadogのAPI keyをSecretManagerに登録 -> Datadogのコンテナの環境変数に設定