### PR TITLE
CodeBuildで利用しているDocker公式イメージをaws/codebuild/standard:2.0に変更

### DIFF
--- a/modules/aws/api/codebuild.tf
+++ b/modules/aws/api/codebuild.tf
@@ -188,7 +188,7 @@ resource "aws_codebuild_project" "push_to_ecr" {
 
   "environment" {
     compute_type                = "BUILD_GENERAL1_SMALL"
-    image                       = "aws/codebuild/docker:18.09.0"
+    image                       = "aws/codebuild/standard:2.0"
     type                        = "LINUX_CONTAINER"
     image_pull_credentials_type = "CODEBUILD"
     privileged_mode             = true


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/99

# Doneの定義
- https://github.com/nekochans/qiita-stocker-terraform/issues/99 の完了条件を満たしている事

# 変更点概要

## 技術的変更点概要
- CodeBuildのベースDockerイメージを `aws/codebuild/standard:2.0` に変更

# 補足情報
設定ファイルも変更する必要がありそれは https://github.com/nekochans/qiita-stocker-backend/pull/200 にて対応済。