### PR TITLE
Nuxtを配信するためのCloudFront + S3Bucketを作成する

### DIFF
--- a/modules/aws/frontend/cloudfront.tf
+++ b/modules/aws/frontend/cloudfront.tf
@@ -1,0 +1,98 @@
+// TODO 本番デプロイ時にドメインを変更する
+resource "aws_route53_record" "nuxt" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  zone_id = data.aws_route53_zone.web.zone_id
+  name = lookup(
+    var.sub_domain_name,
+    "${terraform.workspace}.tmp_name",
+    var.sub_domain_name["default.name"]
+  )
+  type = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.web.domain_name
+    zone_id                = aws_cloudfront_distribution.web.hosted_zone_id
+    evaluate_target_health = false
+  }
+}
+
+resource "aws_cloudfront_distribution" "nuxt" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  origin {
+    domain_name = aws_s3_bucket.nuxt[count.index].bucket_regional_domain_name
+    origin_id   = "S3-${terraform.workspace}-${var.bucket_nuxt}"
+
+    s3_origin_config {
+      origin_access_identity = aws_cloudfront_origin_access_identity.nuxt_origin_access_identity[count.index].cloudfront_access_identity_path
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  enabled             = true
+  is_ipv6_enabled     = true
+  default_root_object = "index.html"
+
+  // TODO 本番デプロイ時にドメインを変更する
+  aliases = ["${lookup(
+    var.sub_domain_name,
+    "${terraform.workspace}.tmp_name",
+    var.sub_domain_name["default.name"]
+  )}.${var.main_domain_name}"]
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    compress         = false
+    target_origin_id = "S3-${terraform.workspace}-${var.bucket_nuxt}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+
+    min_ttl     = 0
+    default_ttl = 86400
+    max_ttl     = 31536000
+  }
+
+  price_class = "PriceClass_All"
+
+  custom_error_response {
+    error_caching_min_ttl = 300
+    error_code            = 403
+    response_code         = 200
+    response_page_path    = "/index.html"
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = 300
+    error_code            = 404
+    response_code         = 404
+    response_page_path    = "/index.html"
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = false
+    acm_certificate_arn            = var.acm["main_arn"]
+    ssl_support_method             = "sni-only"
+    minimum_protocol_version       = "TLSv1.1_2016"
+  }
+
+  logging_config {
+    include_cookies = true
+    bucket          = aws_s3_bucket.nuxt_access_logs[count.index].bucket_domain_name
+    prefix          = "raw/"
+  }
+}

--- a/modules/aws/frontend/s3.tf
+++ b/modules/aws/frontend/s3.tf
@@ -1,0 +1,61 @@
+resource "aws_s3_bucket" "nuxt" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  bucket        = "${terraform.workspace}-${var.bucket_nuxt}"
+  force_destroy = true
+}
+
+resource "aws_s3_bucket" "nuxt_access_logs" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  bucket        = "${terraform.workspace}-${var.bucket_nuxt}-logs"
+  force_destroy = true
+}
+
+data "aws_iam_policy_document" "nust_s3_policy" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  statement {
+    actions   = ["s3:GetObject"]
+    resources = ["${aws_s3_bucket.nuxt[count.index].arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.nuxt_origin_access_identity[count.index].iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "nuxt" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  bucket = aws_s3_bucket.nuxt[count.index].id
+  policy = data.aws_iam_policy_document.nust_s3_policy[count.index].json
+}
+
+data "aws_iam_policy_document" "nuxt_access_logs" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  statement {
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.nuxt_access_logs[count.index].arn}/*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_cloudfront_origin_access_identity.nuxt_origin_access_identity[count.index].iam_arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "nuxt_access_logs" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  bucket = aws_s3_bucket.nuxt_access_logs[count.index].id
+  policy = data.aws_iam_policy_document.nuxt_access_logs[count.index].json
+}
+
+resource "aws_cloudfront_origin_access_identity" "nuxt_origin_access_identity" {
+  count = terraform.workspace == "stg" ? 1 : 0
+
+  comment = "access-identity-S3-${terraform.workspace}-${var.bucket_nuxt}"
+}

--- a/modules/aws/frontend/variable.tf
+++ b/modules/aws/frontend/variable.tf
@@ -4,6 +4,19 @@ variable "bucket" {
   default = "qiita-stocker-frontend"
 }
 
+variable "bucket_nuxt" {
+  type = string
+
+  default = "qiita-stocker-nuxt"
+}
+
+variable "api_gateway" {
+  type = string
+
+  default = "qiita-stocker-nuxt"
+}
+
+
 variable "main_domain_name" {
   type = string
 
@@ -14,8 +27,9 @@ variable "sub_domain_name" {
   type = map(string)
 
   default = {
-    "stg.name"     = "stg-www"
+    "stg.name"     = "tmp-stg-www"
     "default.name" = "www"
+    "stg.tmp_name" = "stg-www"
   }
 }
 


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/111

# Doneの定義
https://github.com/nekochans/qiita-stocker-terraform/issues/111 の完了の定義が満たされていること

# 変更点概要

## 技術的変更点概要
Nuxtの静的なファイルを配信するためのCloudFront + S3Bucketを作成(STG環境のみ)。

# 補足情報
最終的には下記のサービスを利用する想定。
- API Gateway (serverlessで作成)
- Lambda (serverlessで作成)
- CloudFront
- S3

CloudFrontでは、API GatewayとS3にリクエスを振り分ける必要がある。
今回のPRではCloudFrontのOriginsにS3のみを追加。OriginsへのAPI Gatewayの追加は別のPRで対応する。