### PR TITLE
CloudFrontのOriginにAPIGatewayを追加する

### DIFF
--- a/modules/aws/frontend/cloudfront.tf
+++ b/modules/aws/frontend/cloudfront.tf
@@ -16,6 +16,11 @@ resource "aws_route53_record" "nuxt" {
     evaluate_target_health = false
   }
 }
+data "aws_region" "current" {}
+
+data "aws_api_gateway_rest_api" "nuxt" {
+  name = "${terraform.workspace}-${var.api_gateway}"
+}
 
 resource "aws_cloudfront_distribution" "nuxt" {
   count = terraform.workspace == "stg" ? 1 : 0
@@ -29,15 +34,30 @@ resource "aws_cloudfront_distribution" "nuxt" {
     }
   }
 
+  origin {
+    domain_name = "${data.aws_api_gateway_rest_api.nuxt.id}.execute-api.${data.aws_region.current.name}.amazonaws.com"
+    origin_id   = "APIGateway-${terraform.workspace}-${var.api_gateway}"
+    origin_path = "/${terraform.workspace}"
+
+    custom_origin_config {
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+
+      http_port                = 80
+      https_port               = 443
+      origin_keepalive_timeout = 5
+      origin_read_timeout      = 30
+    }
+  }
+
   restrictions {
     geo_restriction {
       restriction_type = "none"
     }
   }
 
-  enabled             = true
-  is_ipv6_enabled     = true
-  default_root_object = "index.html"
+  enabled         = true
+  is_ipv6_enabled = true
 
   // TODO 本番デプロイ時にドメインを変更する
   aliases = ["${lookup(
@@ -50,6 +70,28 @@ resource "aws_cloudfront_distribution" "nuxt" {
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
     cached_methods   = ["GET", "HEAD"]
     compress         = false
+    target_origin_id = "APIGateway-${terraform.workspace}-${var.api_gateway}"
+
+    forwarded_values {
+      query_string = true
+
+      cookies {
+        forward = "all"
+      }
+    }
+
+    viewer_protocol_policy = "https-only"
+
+    min_ttl     = 0
+    default_ttl = 86400
+    max_ttl     = 31536000
+  }
+
+  ordered_cache_behavior {
+    path_pattern     = "_nuxt/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    compress         = true
     target_origin_id = "S3-${terraform.workspace}-${var.bucket_nuxt}"
 
     forwarded_values {
@@ -60,7 +102,7 @@ resource "aws_cloudfront_distribution" "nuxt" {
       }
     }
 
-    viewer_protocol_policy = "https-only"
+    viewer_protocol_policy = "redirect-to-https"
 
     min_ttl     = 0
     default_ttl = 86400


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/111

# Doneの定義
- CloudFrontのOriginにAPI Gatewayが追加されていること
- CloudFrontによってリクエストがS3とAPI Gatewayへ振り分けられていること

# 変更点概要

## 技術的変更点概要
CloudFrontのOriginにAPI Gatewayが追加。
静的リソースはS3から配信し、SSRが必要なリクエストはAPI Gatewayを経由してLambdaが利用される。

# 補足情報
Forward CookiesにALLを設定しているが、whitelistを選択すべきか別途調査を行う。
