### PR TITLE
静的ファイルを配信するためCloudfrontのBehaviorを追加する

### DIFF
--- a/modules/aws/frontend/cloudfront.tf
+++ b/modules/aws/frontend/cloudfront.tf
@@ -109,6 +109,28 @@ resource "aws_cloudfront_distribution" "nuxt" {
     max_ttl     = 31536000
   }
 
+  ordered_cache_behavior {
+    path_pattern     = "assets/*"
+    allowed_methods  = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD"]
+    compress         = true
+    target_origin_id = "S3-${terraform.workspace}-${var.bucket_nuxt}"
+
+    forwarded_values {
+      query_string = false
+
+      cookies {
+        forward = "none"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+
+    min_ttl     = 0
+    default_ttl = 86400
+    max_ttl     = 31536000
+  }
+
   price_class = "PriceClass_All"
 
   custom_error_response {


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-terraform/issues/118

# Doneの定義
https://github.com/nekochans/qiita-stocker-terraform/issues/118 の完了条件が満たされていること

# 変更点概要

## 技術的変更点概要
https://github.com/nekochans/qiita-stocker-nuxt/pull/86 の対応で、S3バケット`/assets/*`配下にfaviconなどの画像を格納し、配信する変更を行う。
Cloudfrontにbehaviorを追加し、`/assets/*`のアクセスはS3バケットの方に振り分けられるように修正。